### PR TITLE
Qt 5.9 - some progress in eventually getting www/qt5-webengine to build [WIP]

### DIFF
--- a/www/qt5-webengine/Makefile
+++ b/www/qt5-webengine/Makefile
@@ -85,7 +85,10 @@ ALL_TARGET=	first
 CONFIGURE_ENV+=	NINJAFLAGS="-j${MAKE_JOBS_NUMBER}" \
 		NINJA_PATH="${LOCALBASE}/bin/ninja"  \
 		PATH=${CONFIGURE_WRKSRC}/bin:${PATH}
-MAKE_ENV+=	CC="${CC}" CXX="${CXX}" ${CONFIGURE_ENV}
+MAKE_ENV+=	CC="${CC}" CXX="${CXX}"			\
+		C_INCLUDE_PATH=${LOCALBASE}/include	\
+		CPLUS_INCLUDE_PATH=${LOCALBASE}/include	\
+		${CONFIGURE_ENV}
 
 post-extract:
 # Install FreeBSD's freebsd.pri file.

--- a/www/qt5-webengine/files/patch-BUILD.gn
+++ b/www/qt5-webengine/files/patch-BUILD.gn
@@ -1,0 +1,174 @@
+--- src/3rdparty/chromium/BUILD.gn.orig	2017-06-20 05:10:02.000000000 -0400
++++ src/3rdparty/chromium/BUILD.gn	2017-12-15 16:23:27.924636000 -0500
+@@ -218,7 +218,7 @@
+     ]
+   }
+ 
+-  if (!is_ios && !is_android && !is_chromecast) {
++  if (!is_ios && !is_android && !is_bsd && !is_chromecast) {
+     deps += [
+       "//chrome",
+       "//chrome/test:browser_tests",
+@@ -286,7 +286,7 @@
+     }
+   }
+ 
+-  if (!is_ios) {
++  if (!is_ios && !is_bsd) {
+     # TODO(GYP): Figure out which of these should actually build on iOS,
+     # and whether there should be other targets that are iOS-only and missing.
+     deps += [
+@@ -336,7 +336,7 @@
+         "//third_party/catapult/telemetry:bitmaptools($host_toolchain)",
+       ]
+     }
+-  } else {
++  } else if (!is_bsd) {
+     deps += [ "//ios:all" ]
+   }
+ 
+@@ -504,18 +504,23 @@
+     ]
+   }
+ 
+-  if (is_linux) {
+-    # The following are definitely linux-only.
++  if (is_linux || is_bsd) {
++    # The following are definitely? linux-only.
+     deps += [
+       "//chrome:manpage",
+       "//chrome:xdg_mime",
+       "//net:disk_cache_memory_test",
+       "//net:quic_client",
+       "//net:quic_server",
+-      "//sandbox/linux:chrome_sandbox",
+-      "//sandbox/linux:sandbox_linux_unittests",
+     ]
+ 
++    if (is_linux) {
++      deps += [
++        "//sandbox/linux:chrome_sandbox",
++        "//sandbox/linux:sandbox_linux_unittests",
++      ]
++    }
++
+     if (use_dbus) {
+       deps += [
+         "//dbus:dbus_test_server",
+@@ -533,7 +538,7 @@
+     }
+   }
+ 
+-  if (is_ios || is_win || (is_linux && !is_chromeos)) {
++  if (is_ios || is_win || is_bsd || (is_linux && !is_chromeos)) {
+     deps += [
+       "//base:base_i18n_perftests",
+       "//base:base_perftests",
+@@ -612,7 +617,7 @@
+     if (enable_nacl) {
+       deps += [ "//components/nacl/loader:nacl_loader_unittests" ]
+ 
+-      if (is_linux) {
++      if (is_linux || is_bsd) {
+         # TODO(dpranke): Figure out what platforms should actually have this.
+         deps += [ "//components/nacl/loader:nacl_helper" ]
+ 
+@@ -722,7 +727,7 @@
+       deps +=
+           [ "//chrome/installer/mini_installer:next_version_mini_installer" ]
+     }
+-  } else if (!is_android && !is_ios) {
++  } else if (!is_android && !is_ios && !is_bsd) {
+     deps += [ "//breakpad:symupload($host_toolchain)" ]
+   }
+ 
+@@ -787,7 +792,7 @@
+     }
+   }
+ 
+-  if (is_linux && !is_chromeos && !is_chromecast) {
++  if ((is_linux || is_bsd) && !is_chromeos && !is_chromecast) {
+     # TODO(GYP): Figure out if any of these should be in gn_all
+     # and figure out how cross-platform they are
+     deps += [
+@@ -840,7 +845,7 @@
+     ]
+ 
+     if (target_cpu == "x86" || target_cpu == "x64") {
+-      if (!is_android) {
++      if (!is_android && !is_bsd) {
+         deps += [ "//chrome/test:load_library_perf_tests" ]
+         if (use_qt) {
+           deps -= [ "//chrome/test:load_library_perf_tests" ]
+@@ -851,7 +856,7 @@
+         "//third_party/libjpeg_turbo:simd_asm",
+       ]
+     }
+-    if (is_linux && current_toolchain == host_toolchain) {
++    if ((is_linux || is_bsd) && current_toolchain == host_toolchain) {
+       deps += [ "//v8:v8_shell" ]
+     }
+   }
+@@ -861,7 +866,7 @@
+   }
+ 
+   if ((is_linux && !is_chromeos && !is_chromecast) || (is_win && use_drfuzz) ||
+-      (use_libfuzzer && is_mac)) {
++      (use_libfuzzer && is_mac) || is_bsd) {
+     deps += [
+       "//testing/libfuzzer/fuzzers",
+       "//testing/libfuzzer/tests:libfuzzer_tests",
+@@ -904,7 +909,7 @@
+ 
+ group("gn_mojo_targets") {
+   testonly = true
+-  if (is_linux && !is_chromeos) {
++  if (is_bsd || (is_linux && !is_chromeos)) {
+     # TODO(GYP): Figure out if any of these should be in gn_all
+     # and figure out how cross-platform they are
+     deps = [
+@@ -930,7 +935,7 @@
+   }
+ }
+ 
+-if (!is_ios) {
++if (!is_ios || !is_bsd) {
+   # This group includes all of the targets needed to build and test Blink,
+   # including running the layout tests (see below).
+   group("blink_tests") {
+@@ -976,7 +981,7 @@
+       data_deps += [ "//content/shell:content_shell_crash_service" ]
+     }
+ 
+-    if (!is_win && !is_android) {
++    if (!is_win && !is_android && !is_bsd) {
+       data_deps += [ "//breakpad:minidump_stackwalk($host_toolchain)" ]
+     }
+ 
+@@ -984,7 +989,7 @@
+       data_deps += [ "//breakpad:dump_syms($host_toolchain)" ]
+     }
+ 
+-    if (is_linux) {
++    if (is_linux && !is_bsd) {
+       data_deps += [ "//breakpad:dump_syms($host_toolchain)" ]
+     }
+ 
+@@ -1006,7 +1011,7 @@
+ group("chromium_builder_perf") {
+   testonly = true
+ 
+-  if (!is_ios && !is_android && !is_chromecast) {
++  if (!is_ios && !is_android && !is_chromecast && !is_bsd) {
+     data_deps = [
+       "//cc:cc_perftests",
+       "//chrome/test:load_library_perf_tests",
+@@ -1043,7 +1048,7 @@
+         "//chrome/installer/mini_installer:mini_installer",
+         "//chrome/test:angle_perftests",
+       ]
+-    } else {
++    } else if (!is_bsd) {
+       data_deps += [ "//breakpad:minidump_stackwalk($host_toolchain)" ]
+     }
+   }

--- a/www/qt5-webengine/files/patch-build_toolchain_gcc__toolchain.gni
+++ b/www/qt5-webengine/files/patch-build_toolchain_gcc__toolchain.gni
@@ -21,12 +21,12 @@
 -    cxx = "$prefix/clang++"
 -    ld = cxx
 +    if (is_bsd) {
-+      cc = "${toolprefix}clang39"
-+      cxx = "${toolprefix}clang++39"
++      cc = "${toolprefix}clang"
++      cxx = "${toolprefix}clang++"
 +      ld = cxx
 +      readelf = "readelf"
-+      ar = "${toolprefix}llvm-ar39"
-+      nm = "${toolprefix}llvm-nm39"
++      ar = "${toolprefix}ar"
++      nm = "${toolprefix}nm"
 +    } else {
 +      prefix = rebase_path("$clang_base_path/bin", root_build_dir)
 +      cc = "$prefix/clang"

--- a/www/qt5-webengine/files/patch-build_toolchain_linux_BUILD.gn
+++ b/www/qt5-webengine/files/patch-build_toolchain_linux_BUILD.gn
@@ -1,0 +1,24 @@
+--- src/3rdparty/chromium/build/toolchain/linux/BUILD.gn.orig	2017-12-15 16:50:54.650099000 -0500
++++ src/3rdparty/chromium/build/toolchain/linux/BUILD.gn	2017-12-15 16:50:13.910751000 -0500
+@@ -6,7 +6,9 @@
+ import("//build/toolchain/gcc_toolchain.gni")
+ 
+ clang_toolchain("clang_arm") {
+-  toolprefix = "arm-linux-gnueabihf-"
++  if (!is_bsd) {
++    toolprefix = "arm-linux-gnueabihf-"
++  }
+   toolchain_args = {
+     current_cpu = "arm"
+     current_os = "linux"
+@@ -14,7 +16,9 @@
+ }
+ 
+ clang_toolchain("clang_arm64") {
+-  toolprefix = "aarch64-linux-gnu-"
++  if (!is_bsd) {
++    toolprefix = "aarch64-linux-gnu-"
++  }
+   toolchain_args = {
+     current_cpu = "arm64"
+     current_os = "linux"

--- a/www/qt5-webengine/files/patch-chrome_common_extensions_api_BUILD.gn
+++ b/www/qt5-webengine/files/patch-chrome_common_extensions_api_BUILD.gn
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/chrome/common/extensions/api/BUILD.gn.orig	2017-12-15 17:02:55.964660000 -0500
++++ src/3rdparty/chromium/chrome/common/extensions/api/BUILD.gn	2017-12-15 17:03:23.878684000 -0500
+@@ -117,7 +117,7 @@
+     "wallpaper.json",
+     "wallpaper_private.json",
+   ]
+-} else if (is_linux || is_win) {
++} else if (is_linux || is_bsd || is_win) {
+   schema_sources += [ "input_ime.json" ]
+ }
+ if (enable_service_discovery) {

--- a/www/qt5-webengine/files/patch-chrome_test_BUILD.gn
+++ b/www/qt5-webengine/files/patch-chrome_test_BUILD.gn
@@ -1,0 +1,158 @@
+--- src/3rdparty/chromium/chrome/test/BUILD.gn.orig	2017-12-15 16:54:01.114272000 -0500
++++ src/3rdparty/chromium/chrome/test/BUILD.gn	2017-12-15 17:01:33.586269000 -0500
+@@ -186,7 +186,7 @@
+     ]
+   }
+ 
+-  if (is_linux) {
++  if (is_linux || is_bsd) {
+     public_deps += [ "//crypto:platform" ]
+   }
+   if (is_mac) {
+@@ -396,7 +396,7 @@
+       "$root_out_dir/test_page.css.mock-http-headers",
+       "$root_out_dir/ui_test.pak",
+     ]
+-    if (is_linux || is_win) {
++    if (is_linux || is_bsd || is_win) {
+       data += [
+         "$root_out_dir/chrome_100_percent.pak",
+         "$root_out_dir/chrome_200_percent.pak",
+@@ -405,7 +405,7 @@
+         "$root_out_dir/resources.pak",
+       ]
+     }
+-    if (is_linux) {
++    if (is_linux || is_bsd) {
+       data += [ "$root_out_dir/libppapi_tests.so" ]
+     }
+ 
+@@ -512,7 +512,7 @@
+           "base/interactive_test_utils_views.cc",
+         ]
+       }
+-      if (is_linux) {
++      if (is_linux || is_bsd) {
+         if (!is_chromeos) {
+           # Desktop linux.
+           sources -= [
+@@ -1890,14 +1890,14 @@
+         sources += [ "//third_party/liblouis/nacl_wrapper/liblouis_wrapper_browsertest.cc" ]
+         deps += [ "//chrome/browser/chromeos" ]
+         data_deps += [ "//third_party/liblouis:liblouis_test_data" ]
+-      } else if (is_linux || is_win) {
++      } else if (is_linux || is_bsd || is_win) {
+         sources += [
+           "../browser/ui/views/ime/ime_warning_bubble_browsertest.cc",
+           "../browser/ui/views/ime/ime_window_browsertest.cc",
+         ]
+       }
+ 
+-      if (is_win || is_linux) {
++      if (is_win || is_linux || is_bsd) {
+         sources += [ "../browser/nacl_host/test/nacl_gdb_browsertest.cc" ]
+         data_deps += [ "//chrome/browser/nacl_host/test:mock_nacl_gdb" ]
+       }
+@@ -1909,7 +1909,7 @@
+         configs +=
+             [ "//build/config/win:default_large_module_incremental_linking" ]
+       }
+-      if (is_linux) {
++      if (is_linux || is_bsd) {
+         data_deps += [ "//components/nacl/loader:nacl_helper" ]
+ 
+         if (enable_nacl_nonsfi) {
+@@ -2016,7 +2016,7 @@
+       }
+     }
+ 
+-    if (is_linux && !is_component_build) {
++    if ((is_linux || is_bsd) && !is_component_build) {
+       # Set rpath to find the CDM adapter even in a non-component build.
+       configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
+     }
+@@ -2243,7 +2243,7 @@
+       if (toolkit_views) {
+         sources -= [ "../browser/ui/views/select_file_dialog_extension_browsertest.cc" ]
+       }
+-      if (is_win || is_linux) {
++      if (is_win || is_linux || is_bsd) {
+         sources +=
+             [ "../browser/ui/views/ime/input_ime_apitest_nonchromeos.cc" ]
+       }
+@@ -2438,7 +2438,7 @@
+         "../browser/extensions/api/networking_private/networking_private_chromeos_apitest.cc",
+       ]
+     }
+-    if (is_mac || is_win || (is_linux && !is_chromeos)) {
++    if (is_mac || is_win || is_bsd || (is_linux && !is_chromeos)) {
+       sources += [
+         # Tests for non mobile and non CrOS (includes Linux, Win, Mac).
+         "../browser/metrics/desktop_session_duration/audible_contents_tracker_browsertest.cc",
+@@ -2626,7 +2626,7 @@
+       "$root_out_dir/pyproto/",
+     ]
+ 
+-    if (is_linux || is_win) {
++    if (is_linux || is_bsd || is_win) {
+       data += [
+         "$root_out_dir/chrome_100_percent.pak",
+         "$root_out_dir/chrome_200_percent.pak",
+@@ -3991,7 +3991,7 @@
+       "//ui/wm",
+     ]
+   }
+-  if (!is_chromeos && is_linux) {
++  if (!is_chromeos && (is_linux || is_bsd)) {
+     sources += [
+       "../browser/password_manager/native_backend_kwallet_x_unittest.cc",
+       "../browser/shell_integration_linux_unittest.cc",
+@@ -4011,7 +4011,7 @@
+   if (use_gio) {
+     deps += [ "//build/linux/libgio" ]
+   }
+-  if (!is_chromeos && !use_ozone && is_linux && use_gtk) {
++  if (!is_chromeos && !use_ozone && (is_linux || is_bsd) && use_gtk) {
+     if (use_gtk3) {
+       deps += [ "//chrome/browser/ui/libgtkui:libgtk3ui" ]
+     } else {
+@@ -4305,18 +4305,18 @@
+       "//components/os_crypt:gnome_keyring_direct",
+     ]
+   }
+-  if (is_linux && !is_chromeos && !use_ozone) {
++  if ((is_linux || is_bsd) && !is_chromeos && !use_ozone) {
+     sources +=
+         [ "../browser/password_manager/native_backend_libsecret_unittest.cc" ]
+     deps += [ "//third_party/libsecret" ]
+   }
+-  if (is_linux && use_aura) {
++  if ((is_linux || is_bsd) && use_aura) {
+     deps += [ "//ui/aura:test_support" ]
+     if (use_dbus) {
+       deps += [ "//dbus:test_support" ]
+     }
+   }
+-  if (is_linux && is_chrome_branded && current_cpu == "x86") {
++  if ((is_linux || is_bsd) && is_chrome_branded && current_cpu == "x86") {
+     ldflags = [ "-Wl,--strip-debug" ]
+   }
+   if (is_mac) {
+@@ -4822,7 +4822,7 @@
+   }
+ }
+ 
+-if (!is_android) {
++if (!is_android && !is_bsd) {
+   # TODO(609855): Make this compile on Android and run on the bots.
+   test("chrome_app_unittests") {
+     sources = [
+@@ -4848,7 +4848,7 @@
+   }
+ }
+ 
+-if (!is_android && !is_ios && !is_chromecast) {
++if (!is_android && !is_ios && !is_chromecast && !is_bsd) {
+   test("performance_browser_tests") {
+     sources = [
+       "../app/chrome_version.rc.version",

--- a/www/qt5-webengine/files/patch-device_bluetooth_BUILD.gn
+++ b/www/qt5-webengine/files/patch-device_bluetooth_BUILD.gn
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/device/bluetooth/BUILD.gn.orig	2017-12-15 17:05:52.395544000 -0500
++++ src/3rdparty/chromium/device/bluetooth/BUILD.gn	2017-12-15 17:06:09.864315000 -0500
+@@ -193,7 +193,7 @@
+     ]
+   }
+ 
+-  if (is_chromeos || is_linux) {
++  if (is_chromeos || (is_linux && !is_bsd)) {
+     if (use_dbus) {
+       sources += [
+         "bluez/bluetooth_adapter_bluez.cc",

--- a/www/qt5-webengine/files/patch-gpu_ipc_service_BUILD.gn
+++ b/www/qt5-webengine/files/patch-gpu_ipc_service_BUILD.gn
@@ -1,0 +1,16 @@
+--- src/3rdparty/chromium/gpu/ipc/service/BUILD.gn.orig	2017-12-15 17:07:13.968625000 -0500
++++ src/3rdparty/chromium/gpu/ipc/service/BUILD.gn	2017-12-15 17:08:34.840034000 -0500
+@@ -104,11 +104,12 @@
+     ]
+     libs += [ "android" ]
+   }
+-  if (is_linux && ui_compositor_image_transport) {
++  if ((is_linux || is_bsd) && ui_compositor_image_transport) {
+     sources += [ "image_transport_surface_linux.cc" ]
+   }
+   if (use_x11) {
+     sources += [ "x_util.h" ]
++    configs += [ "//build/config/linux:x11" ]
+   }
+   if (use_ozone) {
+     sources += [

--- a/www/qt5-webengine/files/patch-third__party_pdfium_pdfium.gni
+++ b/www/qt5-webengine/files/patch-third__party_pdfium_pdfium.gni
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/third_party/pdfium/pdfium.gni.orig	2017-12-15 17:45:56.915001000 -0500
++++ src/3rdparty/chromium/third_party/pdfium/pdfium.gni	2017-12-15 17:45:31.223848000 -0500
+@@ -9,7 +9,7 @@
+ declare_args() {
+   # On Android there's no system FreeType. On Windows and Mac, only a few
+   # methods are used from it.
+-  pdfium_bundle_freetype = !is_linux
++  pdfium_bundle_freetype = false
+ 
+   # Build PDFium either with or without v8 support.
+   pdf_enable_v8 = pdf_enable_v8_override

--- a/www/qt5-webengine/files/patch-tools_perf_chrome__telemetry__build_BUILD.gn
+++ b/www/qt5-webengine/files/patch-tools_perf_chrome__telemetry__build_BUILD.gn
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/tools/perf/chrome_telemetry_build/BUILD.gn.orig	2017-12-15 17:17:15.832652000 -0500
++++ src/3rdparty/chromium/tools/perf/chrome_telemetry_build/BUILD.gn	2017-12-15 17:17:42.136926000 -0500
+@@ -93,7 +93,7 @@
+     data_deps += [ "//chrome:reorder_imports" ]
+   }
+ 
+-  if (is_linux) {
++  if (is_linux && !is_bsd) {
+     data_deps += [
+       "//tools/xdisplaycheck",
+       "//breakpad:dump_syms($host_toolchain)",

--- a/www/qt5-webengine/files/patch-ui_views_mus_BUILD.gn
+++ b/www/qt5-webengine/files/patch-ui_views_mus_BUILD.gn
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/ui/views/mus/BUILD.gn.orig	2017-12-15 17:19:07.971596000 -0500
++++ src/3rdparty/chromium/ui/views/mus/BUILD.gn	2017-12-15 17:19:42.039556000 -0500
+@@ -91,7 +91,7 @@
+     "//ui/wm",
+   ]
+ 
+-  if (is_linux && !is_android) {
++  if ((is_linux || is_bsd) && !is_android) {
+     deps += [ "//components/font_service/public/cpp" ]
+     data_deps = [
+       "//components/font_service",

--- a/www/qt5-webengine/files/patch-v8_BUILD.gn
+++ b/www/qt5-webengine/files/patch-v8_BUILD.gn
@@ -1,6 +1,15 @@
---- src/3rdparty/chromium/v8/BUILD.gn.orig	2017-01-26 00:50:20 UTC
-+++ src/3rdparty/chromium/v8/BUILD.gn
-@@ -2273,7 +2273,7 @@ v8_component("v8_libbase") {
+--- src/3rdparty/chromium/v8/BUILD.gn.orig	2017-06-20 05:10:02.000000000 -0400
++++ src/3rdparty/chromium/v8/BUILD.gn	2017-12-16 11:25:43.174788000 -0500
+@@ -348,7 +348,7 @@
+   # TODO(jochen): Add support for compiling with simulators.
+ 
+   if (is_debug) {
+-    if (is_linux && v8_enable_backtrace) {
++    if ((is_linux || is_bsd) && v8_enable_backtrace) {
+       ldflags += [ "-rdynamic" ]
+     }
+ 
+@@ -2282,7 +2282,7 @@
      sources += [ "src/base/platform/platform-posix.cc" ]
    }
  
@@ -9,7 +18,7 @@
      sources += [
        "src/base/debug/stack_trace_posix.cc",
        "src/base/platform/platform-linux.cc",
-@@ -2283,6 +2283,12 @@ v8_component("v8_libbase") {
+@@ -2292,6 +2292,12 @@
        "dl",
        "rt",
      ]
@@ -22,11 +31,11 @@
    } else if (is_android) {
      if (current_toolchain == host_toolchain) {
        libs = [
-@@ -2420,6 +2426,7 @@ if (current_toolchain == v8_snapshot_too
+@@ -2429,6 +2435,7 @@
      sources = [
        "src/snapshot/mksnapshot.cc",
      ]
-+    libs = ["execinfo"]
++    libs = [ "execinfo" ]
  
      configs = [ ":internal_config" ]
  

--- a/www/qt5-webengine/files/patch-v8_src_globals.h
+++ b/www/qt5-webengine/files/patch-v8_src_globals.h
@@ -1,0 +1,14 @@
+--- src/3rdparty/chromium/v8/src/globals.h.orig	2017-12-15 19:22:04.283569000 -0500
++++ src/3rdparty/chromium/v8/src/globals.h	2017-12-15 19:23:21.959960000 -0500
+@@ -179,7 +179,11 @@
+ const size_t kMaximalCodeRangeSize = 256 * MB;
+ const size_t kCodeRangeAreaAlignment = 256 * MB;
+ #elif V8_HOST_ARCH_PPC && V8_TARGET_ARCH_PPC && V8_OS_LINUX
++#if defined(__FreeBSD__)
++const size_t kMaximalCodeRangeSize = 256 * MB;
++#else
+ const size_t kMaximalCodeRangeSize = 512 * MB;
++#endif
+ const size_t kCodeRangeAreaAlignment = 64 * KB;  // OS page on PPC Linux
+ #else
+ const size_t kMaximalCodeRangeSize = 512 * MB;

--- a/www/qt5-webengine/files/patch-v8_src_log-utils.h
+++ b/www/qt5-webengine/files/patch-v8_src_log-utils.h
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/v8/src/log-utils.h.orig	2017-12-15 19:24:49.335089000 -0500
++++ src/3rdparty/chromium/v8/src/log-utils.h	2017-12-15 19:25:08.702391000 -0500
+@@ -14,6 +14,8 @@
+ #include "src/base/platform/mutex.h"
+ #include "src/flags.h"
+ 
++#include <stdarg.h>
++
+ namespace v8 {
+ namespace internal {
+ 

--- a/www/qt5-webengine/files/patch-v8_src_wasm_wasm-result.h
+++ b/www/qt5-webengine/files/patch-v8_src_wasm_wasm-result.h
@@ -1,0 +1,10 @@
+--- src/3rdparty/chromium/v8/src/wasm/wasm-result.h.orig	2017-12-15 19:26:27.709014000 -0500
++++ src/3rdparty/chromium/v8/src/wasm/wasm-result.h	2017-12-15 19:26:41.537495000 -0500
+@@ -5,6 +5,7 @@
+ #ifndef V8_WASM_RESULT_H_
+ #define V8_WASM_RESULT_H_
+ 
++#include <cstdarg>
+ #include <memory>
+ 
+ #include "src/base/compiler-specific.h"


### PR DESCRIPTION
Applied a few patches to BUILD.gn files from www/iridium and www/chromium.

I also set the localbase include directories in the environment variables from the Makefile because GN wouldn't look in /usr/local and would fail to find the X11 headers during the third_party/angle build.

With this, the build gets up to v8, where it encounters linking issues.

Update: The patches don't apply to this repository because of the update to 5.9.3. The new ones as well as the old ones. I'll mark this as WIP and start working on fixing them.

Good day.