### PR TITLE
Qt 5.9 - some progress on www/qt5-webengine 5.9.3

### DIFF
--- a/www/qt5-webengine/Makefile
+++ b/www/qt5-webengine/Makefile
@@ -55,7 +55,7 @@ PULSEAUDIO_QMAKE_ON=	QT_CONFIG+=pulseaudio
 # We pass `norecursive' to USES=qmake because src/plugins/plugins.pro checks
 # whether webenginewidgets is available, which fails when qmake processes all
 # .pro files at once.
-USES=		gperf jpeg python:2,build pkgconfig \
+USES=		gperf jpeg python:2.7,build pkgconfig \
 		qmake:norecursive,outsource shebangfix
 USE_GNOME=	glib20 libxml2 libxslt
 USE_QT5=	core designer gui location network qml quick webchannel \

--- a/www/qt5-webengine/files/patch-config.tests-enable-on-FreeBSD
+++ b/www/qt5-webengine/files/patch-config.tests-enable-on-FreeBSD
@@ -13,10 +13,3 @@
 +SOURCES += snappy.cpp
  LIBS += -lsnappy
  CONFIG -= qt
---- config.tests/srtp/srtp.pro.orig	2017-04-11 14:08:45 UTC
-+++ config.tests/srtp/srtp.pro
-@@ -1,3 +1,3 @@
--linux:SOURCES += srtp.cpp
-+SOURCES += srtp.cpp
- LIBS += -lsrtp
- CONFIG -= qt

--- a/www/qt5-webengine/files/patch-device_gamepad_gamepad__provider.cc
+++ b/www/qt5-webengine/files/patch-device_gamepad_gamepad__provider.cc
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/device/gamepad/gamepad_provider.cc.orig	2017-02-02 02:02:54 UTC
++++ src/3rdparty/chromium/device/gamepad/gamepad_provider.cc
+@@ -145,7 +145,7 @@ void GamepadProvider::Initialize(std::un
+     monitor->AddDevicesChangedObserver(this);
+ 
+   polling_thread_.reset(new base::Thread("Gamepad polling thread"));
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   // On Linux, the data fetcher needs to watch file descriptors, so the message
+   // loop needs to be a libevent loop.
+   const base::MessageLoop::Type kMessageLoopType = base::MessageLoop::TYPE_IO;

--- a/www/qt5-webengine/files/patch-device_media__transfer__protocol_media__transfer__protocol__daemon__client.h
+++ b/www/qt5-webengine/files/patch-device_media__transfer__protocol_media__transfer__protocol__daemon__client.h
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/device/media_transfer_protocol/media_transfer_protocol_daemon_client.h.orig	2017-02-02 02:02:54 UTC
++++ src/3rdparty/chromium/device/media_transfer_protocol/media_transfer_protocol_daemon_client.h
+@@ -19,7 +19,7 @@
+ #include "base/macros.h"
+ #include "build/build_config.h"
+ 
+-#if !defined(OS_LINUX)
++#if !defined(OS_LINUX) && !defined(OS_BSD)
+ #error "Only used on Linux and ChromeOS"
+ #endif
+ 

--- a/www/qt5-webengine/files/patch-media_ffmpeg_ffmpeg__common.h
+++ b/www/qt5-webengine/files/patch-media_ffmpeg_ffmpeg__common.h
@@ -1,0 +1,31 @@
+--- src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h.orig	2017-11-08 14:13:31.000000000 -0500
++++ src/3rdparty/chromium/media/ffmpeg/ffmpeg_common.h	2017-12-20 18:54:01.787807000 -0500
+@@ -25,8 +25,8 @@
+ // Disable deprecated features which result in spammy compile warnings.  This
+ // list of defines must mirror those in the 'defines' section of FFmpeg's
+ // BUILD.gn file or the headers below will generate different structures!
+-#if !defined(USE_SYSTEM_FFMPEG)
+-#define FF_API_CONVERGENCE_DURATION 0
++// #if !defined(USE_SYSTEM_FFMPEG)
++// #define FF_API_CONVERGENCE_DURATION 0
+ // Upstream libavcodec/utils.c still uses the deprecated
+ // av_dup_packet(), causing deprecation warnings.
+ // The normal fix for such things is to disable the feature as below,
+@@ -34,16 +34,13 @@
+ // (In this case, the fix is replacing the call with a new function.)
+ // In the meantime, we directly disable those warnings in the C file.
+ //#define FF_API_AVPACKET_OLD_API 0
+-#endif
++// #endif
+ 
+ // Temporarily disable possible loss of data warning.
+ // TODO(scherkus): fix and upstream the compiler warnings.
+ MSVC_PUSH_DISABLE_WARNING(4244);
+ #include <libavcodec/avcodec.h>
+ #include <libavformat/avformat.h>
+-#if !defined(USE_SYSTEM_FFMPEG)
+-#include <libavformat/internal.h>
+-#endif
+ #include <libavformat/avio.h>
+ #include <libavutil/avutil.h>
+ #include <libavutil/imgutils.h>

--- a/www/qt5-webengine/files/patch-media_filters_ffmpeg__demuxer.cc
+++ b/www/qt5-webengine/files/patch-media_filters_ffmpeg__demuxer.cc
@@ -1,0 +1,29 @@
+--- src/3rdparty/chromium/media/filters/ffmpeg_demuxer.cc.orig	2017-11-08 14:13:31.000000000 -0500
++++ src/3rdparty/chromium/media/filters/ffmpeg_demuxer.cc	2017-12-20 19:01:30.286801000 -0500
+@@ -1198,26 +1198,6 @@
+   // If no estimate is found, the stream entry will be kInfiniteDuration.
+   std::vector<base::TimeDelta> start_time_estimates(format_context->nb_streams,
+                                                     kInfiniteDuration);
+-#if !defined(USE_SYSTEM_FFMPEG)
+-  const AVFormatInternal* internal = format_context->internal;
+-  if (internal && internal->packet_buffer &&
+-      format_context->start_time != static_cast<int64_t>(AV_NOPTS_VALUE)) {
+-    struct AVPacketList* packet_buffer = internal->packet_buffer;
+-    while (packet_buffer != internal->packet_buffer_end) {
+-      DCHECK_LT(static_cast<size_t>(packet_buffer->pkt.stream_index),
+-                start_time_estimates.size());
+-      const AVStream* stream =
+-          format_context->streams[packet_buffer->pkt.stream_index];
+-      if (packet_buffer->pkt.pts != static_cast<int64_t>(AV_NOPTS_VALUE)) {
+-        const base::TimeDelta packet_pts =
+-            ConvertFromTimeBase(stream->time_base, packet_buffer->pkt.pts);
+-        if (packet_pts < start_time_estimates[stream->index])
+-          start_time_estimates[stream->index] = packet_pts;
+-      }
+-      packet_buffer = packet_buffer->next;
+-    }
+-  }
+-#endif
+   std::unique_ptr<MediaTracks> media_tracks(new MediaTracks());
+ 
+   DCHECK(track_id_to_demux_stream_map_.empty());

--- a/www/qt5-webengine/files/patch-mkspecs_features_functions.prf
+++ b/www/qt5-webengine/files/patch-mkspecs_features_functions.prf
@@ -1,18 +1,18 @@
 Include the freebsd.pri file provided by the port, to pass FreeBSD specific
-settings to gyp.
+settings to gn.
 
---- mkspecs/features/functions.prf
+--- mkspecs/features/functions.prf.orig
 +++ mkspecs/features/functions.prf
-@@ -15,7 +15,7 @@ defineTest(isQtMinimum) {
+@@ -15,7 +15,7 @@
  
  defineTest(isPlatformSupported) {
    QT_FOR_CONFIG += gui-private
 -  linux {
 +  unix {
-     !gcc:!clang {
+     if(!gcc:!clang)|intel_icc {
        skipBuild("Qt WebEngine on Linux requires clang or GCC.")
        return(false)
-@@ -358,6 +358,7 @@ defineReplace(gnArgs) {
+@@ -367,6 +367,7 @@
      }
      macos: include($$QTWEBENGINE_ROOT/src/core/config/mac_osx.pri)
      win32: include($$QTWEBENGINE_ROOT/src/core/config/windows.pri)
@@ -20,7 +20,7 @@ settings to gyp.
      isEmpty(gn_args): error(No gn_args found please make sure you have valid configuration.)
      return($$gn_args)
  }
-@@ -377,6 +378,7 @@ defineReplace(gnOS) {
+@@ -386,6 +387,7 @@
      macos: return(mac)
      win32: return(win)
      linux: return(linux)

--- a/www/qt5-webengine/files/patch-services_ui_public_cpp_gles2__context.cc
+++ b/www/qt5-webengine/files/patch-services_ui_public_cpp_gles2__context.cc
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/services/ui/public/cpp/gles2_context.cc.orig	2017-02-02 02:02:57 UTC
++++ src/3rdparty/chromium/services/ui/public/cpp/gles2_context.cc
+@@ -46,7 +46,7 @@ bool GLES2Context::Initialize(
+   gpu::CommandBuffer* command_buffer = command_buffer_proxy_impl_.get();
+   gpu::GpuControl* gpu_control = command_buffer_proxy_impl_.get();
+ 
+-  constexpr gpu::SharedMemoryLimits default_limits;
++  constexpr gpu::SharedMemoryLimits default_limits = gpu::SharedMemoryLimits();
+   gles2_helper_.reset(new gpu::gles2::GLES2CmdHelper(command_buffer));
+   if (!gles2_helper_->Initialize(default_limits.command_buffer_size))
+     return false;

--- a/www/qt5-webengine/files/patch-services_ui_surfaces_surfaces__context__provider.cc
+++ b/www/qt5-webengine/files/patch-services_ui_surfaces_surfaces__context__provider.cc
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/services/ui/surfaces/surfaces_context_provider.cc.orig	2017-02-02 02:02:57 UTC
++++ src/3rdparty/chromium/services/ui/surfaces/surfaces_context_provider.cc
+@@ -78,7 +78,7 @@ bool SurfacesContextProvider::BindToCurr
+   gpu::CommandBuffer* command_buffer = command_buffer_proxy_impl_.get();
+ 
+   gles2_helper_.reset(new gpu::gles2::GLES2CmdHelper(command_buffer));
+-  constexpr gpu::SharedMemoryLimits default_limits;
++  constexpr gpu::SharedMemoryLimits default_limits = gpu::SharedMemoryLimits();
+   if (!gles2_helper_->Initialize(default_limits.command_buffer_size))
+     return false;
+   gles2_helper_->SetAutomaticFlushes(false);


### PR DESCRIPTION
At least it should get past configure now. The build still fails in v8 because of a linking issue.

update:
--
I also ported the rest of the patches from chromium 56 which are compatible. In theory any remaining issues with chromium are with the build system or come from the patches applied by qt.

The build still fails while linking the v8 mkpeephole executable. From what I know this is the first binary that's linked using the toolchain setup in src/3rdparty/chromium/build/toolchain/. The previous one used the bootstrap script. With ld.lld and GNU ld, the linker complains about not finding a symbol declared in logging.cc which is part of the v8_libbase dependency to the executable build. With ld.gold, the linker complains about a corrupted archive file. I'm looking into the files related to the toolchain now.