### PR TITLE
Don't rely on cmake to find the "right" clang installation

### DIFF
--- a/devel/kdevelop/Makefile
+++ b/devel/kdevelop/Makefile
@@ -2,6 +2,7 @@
 
 PORTNAME=	kdevelop
 DISTVERSION=	5.3.0
+PORTREVISION=	1
 CATEGORIES=	devel kde
 MASTER_SITES=	KDE/stable/kdevelop/${DISTVERSION}/src
 DIST_SUBDIR=	KDE/kdevelop
@@ -18,7 +19,7 @@ LIB_DEPENDS=	libkasten3controllers.so:devel/okteta \
 		libsvn_client-1.so:devel/subversion \
 		libboost_thread.so:devel/boost-libs \
 		libkomparediff2.so:textproc/libkomparediff2 \
-		libclang.so.6:devel/llvm60
+		libclang.so.${LLVM_VERSION:C/([1-9])([0-9])/\1/}:devel/llvm${LLVM_VERSION}
 RUN_DEPENDS=	gmake:devel/gmake
 
 USES=		cmake:outsource compiler:c++11-lib desktop-file-utils \
@@ -43,8 +44,12 @@ WEBENGINE_USE=	QT=location,webchannel,webengine
 WEBENGINE_USE_OFF=	QT=webkit
 WEBENGINE_CMAKE_OFF=	-DCMAKE_DISABLE_FIND_PACKAGE_Qt5WebEngineWidgets:BOOL=TRUE
 
+LLVM_VERSION?=	60
+
 SHEBANG_LANG=	zsh
 zsh_OLD_CMD=	/bin/zsh
 zsh_CMD=	${LOCALBASE}/bin/zsh
+
+CMAKE_ARGS=	-DCMAKE_POLICY_DEFAULT_CMP0074=NEW -DLLVM_ROOT=${LOCALBASE}/llvm${LLVM_VERSION}
 
 .include <bsd.port.mk>


### PR DESCRIPTION
Don't rely on cmake to find the "right" clang installation, but
tell it where it's installed instead.

Enabling the cmake policy is unneccessary right now because
kdevelop provides it's own findLLVM.cmake, that ignores the
policy, but this could change at some point in the future.

While here, introduce the LLVM_VERSION make variable and have
it default to 60, which is the version that was used by cmake
on stable/11 before (the LIBDEPENDS in the makefile was not
communicated to cmake before this commit).

Eventually LLVM_VERSION shouldn't be hard-coded here,
but defaulting to MESA_LLVM_VER, which is installed
anyways because x11 depends on it.

This commit has no effect on "default setups", i.e. those
that don't define LLVM_VERSION to ports and don't define
LLVM_ROOT as an environment variable either.
As such nondefault setups probably exist, bump PORTREVISION.