### PR TITLE
www/qt5-webengine: Update to 5.12.2

### DIFF
--- a/www/qt5-webengine/Makefile
+++ b/www/qt5-webengine/Makefile
@@ -49,7 +49,7 @@ LIB_DEPENDS=	libavcodec.so:multimedia/ffmpeg \
 		libwebp.so:graphics/webp
 
 DISTINFO_FILE=	${.CURDIR}/distinfo
-QT5_VERSION=	5.12.1
+QT5_VERSION=	5.12.2
 
 OPTIONS_SINGLE=		AUDIO
 OPTIONS_SINGLE_AUDIO=	ALSA PULSEAUDIO SNDIO
@@ -73,7 +73,7 @@ SNDIO_VARS_OFF=		QMAKE_CONFIGURE_ARGS+=-no-sndio
 # We pass `norecursive' to USES=qmake because src/plugins/plugins.pro checks
 # whether webenginewidgets is available, which fails when qmake processes all
 # .pro files at once.
-USES=		gperf jpeg python:2.7,build pkgconfig \
+USES=		gl gnome gperf jpeg python:2.7,build pkgconfig \
 		qmake:norecursive,outsource qt-dist:5,webengine shebangfix
 USE_GL=		gl
 USE_GNOME=	glib20 libxml2 libxslt

--- a/www/qt5-webengine/distinfo
+++ b/www/qt5-webengine/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1549725518
-SHA256 (KDE/Qt/5.12.1/qtwebengine-everywhere-src-5.12.1.tar.xz) = 43e91e06bc4a60ef0f91d15ae06425cf9c6b4f7dafe960259a5b013c687c3bd0
-SIZE (KDE/Qt/5.12.1/qtwebengine-everywhere-src-5.12.1.tar.xz) = 249191844
+TIMESTAMP = 1553273996
+SHA256 (KDE/Qt/5.12.2/qtwebengine-everywhere-src-5.12.2.tar.xz) = 082b1d6e60c1be61881bc8533acc67d9688620d6b3a538417f62b27b34ead493
+SIZE (KDE/Qt/5.12.2/qtwebengine-everywhere-src-5.12.2.tar.xz) = 249240772


### PR DESCRIPTION
Add "gl" and "gnome" back to USES to prevent the following warnings from bsd.port.mk:

- "Using USE_GL alone is deprecated, please add USES=gl"
- "Using USE_GNOME alone is deprecated, please add USES=gnome"