### PR TITLE
www/qt5-webengine: Add support for WebRTC

### DIFF
--- a/www/qt5-webengine/Makefile
+++ b/www/qt5-webengine/Makefile
@@ -20,7 +20,7 @@
 
 PORTNAME=	webengine
 DISTVERSION=	${QT5_VERSION}
-PORTREVISION=	1
+PORTREVISION=	2
 CATEGORIES=	www
 PKGNAMEPREFIX=	qt5-
 
@@ -86,7 +86,7 @@ USE_XORG=	x11 xcb xcomposite xcursor xext xi xorgproto \
 
 USE_LDCONFIG=	${QT_LIBDIR}
 
-QMAKE_CONFIGURE_ARGS=	-proprietary-codecs -system-ffmpeg -disable-webrtc
+QMAKE_CONFIGURE_ARGS=	-proprietary-codecs -system-ffmpeg
 
 # We could just set it to an empty string as well. "all" does not account for
 # dependencies correctly in the generated Makefiles, use the right target here.

--- a/www/qt5-webengine/files/patch-clang
+++ b/www/qt5-webengine/files/patch-clang
@@ -1,4 +1,4 @@
---- src/3rdparty/chromium/base/strings/safe_sprintf_unittest.cc.orig	2018-11-13 18:25:11 UTC
+--- src/3rdparty/chromium/base/strings/safe_sprintf_unittest.cc.orig	2019-03-07 09:23:57 UTC
 +++ src/3rdparty/chromium/base/strings/safe_sprintf_unittest.cc
 @@ -730,6 +730,7 @@ TEST(SafeSPrintfTest, EmbeddedNul) {
  }
@@ -16,7 +16,7 @@
  #if defined(__GCC__)
  #pragma GCC diagnostic pop
  #endif
---- src/3rdparty/chromium/base/threading/thread_local_storage_unittest.cc.orig	2018-11-13 18:25:11 UTC
+--- src/3rdparty/chromium/base/threading/thread_local_storage_unittest.cc.orig	2019-03-07 09:23:57 UTC
 +++ src/3rdparty/chromium/base/threading/thread_local_storage_unittest.cc
 @@ -86,7 +86,7 @@ class ThreadLocalStorageRunner : public DelegateSimple
  void ThreadLocalStorageCleanup(void *value) {
@@ -27,7 +27,7 @@
    if (*ptr == kFinalTlsValue)
      return;  // We've been called enough times.
    ASSERT_LT(kFinalTlsValue, *ptr);
---- src/3rdparty/chromium/media/audio/audio_output_proxy_unittest.cc.orig	2018-11-13 18:25:11 UTC
+--- src/3rdparty/chromium/media/audio/audio_output_proxy_unittest.cc.orig	2019-03-07 09:23:57 UTC
 +++ src/3rdparty/chromium/media/audio/audio_output_proxy_unittest.cc
 @@ -410,7 +410,7 @@ class AudioOutputProxyTest : public testing::Test {
      // |stream| is closed at this point. Start() should reopen it again.
@@ -38,7 +38,18 @@
  
      EXPECT_CALL(callback_, OnError()).Times(2);
  
---- src/3rdparty/chromium/third_party/sfntly/src/cpp/src/sfntly/table/core/cmap_table.cc.orig	2018-11-13 18:25:11 UTC
+--- src/3rdparty/chromium/third_party/libjingle_xmpp/task_runner/taskrunner.cc.orig	2019-03-07 09:23:57 UTC
++++ src/3rdparty/chromium/third_party/libjingle_xmpp/task_runner/taskrunner.cc
+@@ -95,7 +95,7 @@ void TaskRunner::InternalRunTasks(bool in_destructor) 
+   std::vector<Task *>::iterator it;
+   it = std::remove(tasks_.begin(),
+                    tasks_.end(),
+-                   reinterpret_cast<Task *>(NULL));
++                   static_cast<Task *>(NULL));
+ 
+   tasks_.erase(it, tasks_.end());
+ 
+--- src/3rdparty/chromium/third_party/sfntly/src/cpp/src/sfntly/table/core/cmap_table.cc.orig	2019-03-07 09:23:57 UTC
 +++ src/3rdparty/chromium/third_party/sfntly/src/cpp/src/sfntly/table/core/cmap_table.cc
 @@ -439,7 +439,7 @@ CMapTable::CMapFormat0::Builder::Builder(
  }

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_create__video__capture__device__factory.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_create__video__capture__device__factory.cc
@@ -1,0 +1,20 @@
+--- src/3rdparty/chromium/media/capture/video/create_video_capture_device_factory.cc.orig	2019-03-07 09:23:57 UTC
++++ src/3rdparty/chromium/media/capture/video/create_video_capture_device_factory.cc
+@@ -10,7 +10,7 @@
+ #include "media/capture/video/fake_video_capture_device_factory.h"
+ #include "media/capture/video/file_video_capture_device_factory.h"
+ 
+-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
++#if (defined(OS_LINUX) && !defined(OS_CHROMEOS)) || defined(OS_BSD)
+ #include "media/capture/video/linux/video_capture_device_factory_linux.h"
+ #elif defined(OS_CHROMEOS)
+ #include "media/capture/video/chromeos/public/cros_features.h"
+@@ -31,7 +31,7 @@ namespace {
+ std::unique_ptr<VideoCaptureDeviceFactory>
+ CreatePlatformSpecificVideoCaptureDeviceFactory(
+     scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner) {
+-#if defined(OS_LINUX) && !defined(OS_CHROMEOS)
++#if (defined(OS_LINUX) && !defined(OS_CHROMEOS)) || defined(OS_BSD)
+   return std::make_unique<VideoCaptureDeviceFactoryLinux>(ui_task_runner);
+ #elif defined(OS_CHROMEOS)
+   // On Chrome OS we have to support two use cases:

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_shared__memory__handle__provider.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_shared__memory__handle__provider.cc
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/media/capture/video/shared_memory_handle_provider.cc.orig	2019-03-07 09:23:57 UTC
++++ src/3rdparty/chromium/media/capture/video/shared_memory_handle_provider.cc
+@@ -63,7 +63,7 @@ bool SharedMemoryHandleProvider::InitFromMojoHandle(
+   return true;
+ }
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ bool SharedMemoryHandleProvider::InitAsReadOnlyFromRawFileDescriptor(
+     mojo::ScopedHandle fd_handle,
+     uint32_t memory_size_in_bytes) {

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_shared__memory__handle__provider.h
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_shared__memory__handle__provider.h
@@ -1,0 +1,11 @@
+--- src/3rdparty/chromium/media/capture/video/shared_memory_handle_provider.h.orig	2019-03-07 09:23:57 UTC
++++ src/3rdparty/chromium/media/capture/video/shared_memory_handle_provider.h
+@@ -38,7 +38,7 @@ class CAPTURE_EXPORT SharedMemoryHandleProvider
+ 
+ // This requires platforms where base::SharedMemoryHandle is backed by a
+ // file descriptor.
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   bool InitAsReadOnlyFromRawFileDescriptor(mojo::ScopedHandle fd_handle,
+                                            uint32_t memory_size_in_bytes);
+ #endif  // defined(OS_LINUX)


### PR DESCRIPTION
It compiles fine but I haven't tested fully in runtime so far. But visiting https://test.webrtc.org/ won't crash so far as it always was the case without the patches.