### PR TITLE
www/qt5-webengine: Fix runtime issues with the 5.14.0 release

### DIFF
--- a/www/qt5-webengine/files/patch-configure.pri
+++ b/www/qt5-webengine/files/patch-configure.pri
@@ -9,13 +9,22 @@
          qtwebengine_platformError("Unknown platform. Qt WebEngine only supports Linux, Windows, and macOS.")
      } else {
          linux:qtwebengine_isLinuxPlatformSupported() {
-@@ -125,6 +125,9 @@ defineTest(qtConfTest_detectPlatform) {
-         }
+@@ -126,6 +126,9 @@ defineTest(qtConfTest_detectPlatform) {
          macos:qtwebengine_isMacOsPlatformSupported() {
              $${1}.platform = "macos"
-+        }
+         }
 +        unix:qtwebengine_isLinuxPlatformSupported() {
 +            $${1}.platform = "linux"
-         }
++        }
      }
  
+     !isEmpty(platformError) {
+@@ -163,7 +166,7 @@ defineTest(qtConfTest_detectNinja) {
+     !isEmpty(ninja) {
+         qtLog("Found ninja from path: $$ninja")
+         qtRunLoggedCommand("$$ninja --version", version)|return(false)
+-        contains(version, "1.[7-9].*"): return(true)
++        contains(version, "1\.([7-9]|1[0-9])\..*"): return(true)
+         qtLog("Ninja version too old")
+     }
+     qtLog("Building own ninja")

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_content_browser_builtin__service__manifests.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_content_browser_builtin__service__manifests.cc
@@ -1,0 +1,20 @@
+--- src/3rdparty/chromium/content/browser/builtin_service_manifests.cc.orig	2019-11-27 21:12:25 UTC
++++ src/3rdparty/chromium/content/browser/builtin_service_manifests.cc
+@@ -32,7 +32,7 @@
+ #include "services/tracing/manifest.h"
+ #include "services/video_capture/public/cpp/manifest.h"
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ #include "components/services/font/public/cpp/manifest.h"  // nogncheck
+ #endif
+ 
+@@ -99,7 +99,7 @@ const std::vector<service_manager::Manifest>& GetBuilt
+                   : service_manager::Manifest::ExecutionMode::
+                         kInProcessBuiltin),
+ #endif
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+           font_service::GetManifest(),
+ #endif
+ #if defined(OS_CHROMEOS)

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_content_browser_service__manager_service__manager__context.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_content_browser_service__manager_service__manager__context.cc
@@ -1,0 +1,35 @@
+--- src/3rdparty/chromium/content/browser/service_manager/service_manager_context.cc.orig	2019-11-27 21:12:25 UTC
++++ src/3rdparty/chromium/content/browser/service_manager/service_manager_context.cc
+@@ -98,7 +98,7 @@
+ #include "content/public/android/content_jni_headers/ContentNfcDelegate_jni.h"
+ #endif
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ #include "components/services/font/font_service_app.h"
+ #include "components/services/font/public/mojom/constants.mojom.h"  // nogncheck
+ #endif
+@@ -341,12 +341,12 @@ void CreateInProcessAudioService(
+                      BrowserMainLoop::GetAudioManager(), std::move(request)));
+ }
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ std::unique_ptr<service_manager::Service> CreateFontService(
+     service_manager::mojom::ServiceRequest request) {
+   return std::make_unique<font_service::FontServiceApp>(std::move(request));
+ }
+-#endif  // defined(OS_LINUX)
++#endif  // defined(OS_LINUX) || defined(OS_BSD)
+ 
+ std::unique_ptr<service_manager::Service> CreateResourceCoordinatorService(
+     service_manager::mojom::ServiceRequest request) {
+@@ -657,7 +657,7 @@ ServiceManagerContext::ServiceManagerContext(
+         base::BindRepeating(&CreateVideoCaptureService));
+   }
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   RegisterInProcessService(
+       font_service::mojom::kServiceName,
+       base::CreateSequencedTaskRunnerWithTraits(

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_mojo_interfaces_video__frame__struct__traits.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_mojo_interfaces_video__frame__struct__traits.cc
@@ -1,0 +1,20 @@
+--- src/3rdparty/chromium/media/mojo/interfaces/video_frame_struct_traits.cc.orig	2020-04-05 20:03:42 UTC
++++ src/3rdparty/chromium/media/mojo/interfaces/video_frame_struct_traits.cc
+@@ -49,7 +49,7 @@ media::mojom::VideoFrameDataPtr MakeVideoFrameData(
+             mojo_frame->PlaneOffset(media::VideoFrame::kVPlane)));
+   }
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   if (input->storage_type() == media::VideoFrame::STORAGE_DMABUFS) {
+     std::vector<mojo::ScopedHandle> dmabuf_fds;
+ 
+@@ -142,7 +142,7 @@ bool StructTraits<media::mojom::VideoFrameDataView,
+         shared_buffer_data.u_offset(), shared_buffer_data.v_offset(),
+         shared_buffer_data.y_stride(), shared_buffer_data.u_stride(),
+         shared_buffer_data.v_stride(), timestamp);
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   } else if (data.is_dmabuf_data()) {
+     media::mojom::DmabufVideoFrameDataDataView dmabuf_data;
+     data.GetDmabufDataDataView(&dmabuf_data);

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_services_content_simple__browser_simple__browser__service.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_services_content_simple__browser_simple__browser__service.cc
@@ -1,0 +1,20 @@
+--- src/3rdparty/chromium/services/content/simple_browser/simple_browser_service.cc.orig	2019-11-27 21:12:25 UTC
++++ src/3rdparty/chromium/services/content/simple_browser/simple_browser_service.cc
+@@ -7,7 +7,7 @@
+ #include "build/build_config.h"
+ #include "services/content/simple_browser/window.h"
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ #include "third_party/skia/include/ports/SkFontConfigInterface.h"  // nogncheck
+ #endif
+ 
+@@ -23,7 +23,7 @@ SimpleBrowserService::~SimpleBrowserService() = defaul
+ 
+ void SimpleBrowserService::OnStart() {
+   if (ui_initialization_mode_ == UIInitializationMode::kInitializeUI) {
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+     font_loader_ =
+         sk_make_sp<font_service::FontLoader>(service_binding_.GetConnector());
+     SkFontConfigInterface::SetGlobal(font_loader_);

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_services_content_simple__browser_simple__browser__service.h
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_services_content_simple__browser_simple__browser__service.h
@@ -1,0 +1,20 @@
+--- src/3rdparty/chromium/services/content/simple_browser/simple_browser_service.h.orig	2019-11-27 21:12:25 UTC
++++ src/3rdparty/chromium/services/content/simple_browser/simple_browser_service.h
+@@ -15,7 +15,7 @@
+ #include "services/service_manager/public/cpp/service_binding.h"
+ #include "services/service_manager/public/mojom/service.mojom.h"
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+ #include "components/services/font/public/cpp/font_loader.h"  // nogncheck
+ #endif
+ 
+@@ -45,7 +45,7 @@ class COMPONENT_EXPORT(SIMPLE_BROWSER) SimpleBrowserSe
+   // service_manager::Service:
+   void OnStart() override;
+ 
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   sk_sp<font_service::FontLoader> font_loader_;
+ #endif
+ 

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_ui_gfx_mojo_buffer__types__struct__traits.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_ui_gfx_mojo_buffer__types__struct__traits.cc
@@ -1,0 +1,66 @@
+--- src/3rdparty/chromium/ui/gfx/mojo/buffer_types_struct_traits.cc.orig	2020-04-05 18:54:38 UTC
++++ src/3rdparty/chromium/ui/gfx/mojo/buffer_types_struct_traits.cc
+@@ -24,15 +24,15 @@ bool StructTraits<gfx::mojom::BufferUsageAndFormatData
+   return data.ReadUsage(&out->usage) && data.ReadFormat(&out->format);
+ }
+ 
+-#if defined(OS_LINUX) || defined(USE_OZONE)
++#if defined(OS_LINUX) || defined(OS_BSD) || defined(USE_OZONE)
+ mojo::ScopedHandle StructTraits<
+     gfx::mojom::NativePixmapPlaneDataView,
+     gfx::NativePixmapPlane>::buffer_handle(gfx::NativePixmapPlane& plane) {
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   return mojo::WrapPlatformFile(plane.fd.release());
+ #elif defined(OS_FUCHSIA)
+   return mojo::WrapPlatformHandle(mojo::PlatformHandle(std::move(plane.vmo)));
+-#endif  // defined(OS_LINUX)
++#endif  // defined(OS_LINUX) || defined(OS_BSD)
+ }
+ 
+ bool StructTraits<
+@@ -45,7 +45,7 @@ bool StructTraits<
+ 
+   mojo::PlatformHandle handle =
+       mojo::UnwrapPlatformHandle(data.TakeBufferHandle());
+-#if defined(OS_LINUX)
++#if defined(OS_LINUX) || defined(OS_BSD)
+   if (!handle.is_fd())
+     return false;
+   out->fd = handle.TakeFD();
+@@ -53,7 +53,7 @@ bool StructTraits<
+   if (!handle.is_handle())
+     return false;
+   out->vmo = zx::vmo(handle.TakeHandle());
+-#endif  // defined(OS_LINUX)
++#endif  // defined(OS_LINUX) || defined(OS_BSD)
+ 
+   return true;
+ }
+@@ -71,7 +71,7 @@ bool StructTraits<
+   out->modifier = data.modifier();
+   return data.ReadPlanes(&out->planes);
+ }
+-#endif  // defined(OS_LINUX) || defined(USE_OZONE)
++#endif  // defined(OS_LINUX) || defined(OS_BSD) || defined(USE_OZONE)
+ 
+ gfx::mojom::GpuMemoryBufferPlatformHandlePtr StructTraits<
+     gfx::mojom::GpuMemoryBufferHandleDataView,
+@@ -84,7 +84,7 @@ gfx::mojom::GpuMemoryBufferPlatformHandlePtr StructTra
+       return gfx::mojom::GpuMemoryBufferPlatformHandle::NewSharedMemoryHandle(
+           std::move(handle.region));
+     case gfx::NATIVE_PIXMAP:
+-#if defined(OS_LINUX) || defined(USE_OZONE)
++#if defined(OS_LINUX) || defined(OS_BSD) || defined(USE_OZONE)
+       return gfx::mojom::GpuMemoryBufferPlatformHandle::NewNativePixmapHandle(
+           std::move(handle.native_pixmap_handle));
+ #else
+@@ -160,7 +160,7 @@ bool StructTraits<gfx::mojom::GpuMemoryBufferHandleDat
+       out->type = gfx::SHARED_MEMORY_BUFFER;
+       out->region = std::move(platform_handle->get_shared_memory_handle());
+       return true;
+-#if defined(OS_LINUX) || defined(USE_OZONE)
++#if defined(OS_LINUX) || defined(OS_BSD) || defined(USE_OZONE)
+     case gfx::mojom::GpuMemoryBufferPlatformHandleDataView::Tag::
+         NATIVE_PIXMAP_HANDLE:
+       out->type = gfx::NATIVE_PIXMAP;

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_ui_gfx_mojo_buffer__types__struct__traits.h
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_ui_gfx_mojo_buffer__types__struct__traits.h
@@ -1,0 +1,20 @@
+--- src/3rdparty/chromium/ui/gfx/mojo/buffer_types_struct_traits.h.orig	2020-04-05 18:58:53 UTC
++++ src/3rdparty/chromium/ui/gfx/mojo/buffer_types_struct_traits.h
+@@ -193,7 +193,7 @@ struct StructTraits<gfx::mojom::GpuMemoryBufferIdDataV
+   }
+ };
+ 
+-#if defined(OS_LINUX) || defined(USE_OZONE)
++#if defined(OS_LINUX) || defined(OS_BSD) || defined(USE_OZONE)
+ template <>
+ struct StructTraits<gfx::mojom::NativePixmapPlaneDataView,
+                     gfx::NativePixmapPlane> {
+@@ -237,7 +237,7 @@ struct StructTraits<gfx::mojom::NativePixmapHandleData
+   static bool Read(gfx::mojom::NativePixmapHandleDataView data,
+                    gfx::NativePixmapHandle* out);
+ };
+-#endif  // defined(OS_LINUX) || defined(USE_OZONE)
++#endif  // defined(OS_LINUX) || defined(OS_BSD) || defined(USE_OZONE)
+ 
+ template <>
+ struct StructTraits<gfx::mojom::GpuMemoryBufferHandleDataView,


### PR DESCRIPTION
**Note:** The branch name should be `qt5-webengine-5.14.0-runtime`

Some files were renamed with the Chromium 78 release (mostly the mojo
stuff).

Files for the font service were taken from the Chromium 76 release.

The commit also contains the fix for detecting Ninja >= 1.10 by using an
official backport from upstream's 5.14.2 branch.

TODO:

Intensive runtime testing (various sites with media contents, playing
around with many tabs, etc.)