### PR TITLE
www/qt5-webengine: Un-remove v4l video capture support

### DIFF
--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_linux_video__capture__device__factory__linux.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_linux_video__capture__device__factory__linux.cc
@@ -1,32 +1,10 @@
---- src/3rdparty/chromium/media/capture/video/linux/video_capture_device_factory_linux.cc.orig	2019-03-01 17:04:22 UTC
+--- src/3rdparty/chromium/media/capture/video/linux/video_capture_device_factory_linux.cc.orig	2019-11-27 21:12:25 UTC
 +++ src/3rdparty/chromium/media/capture/video/linux/video_capture_device_factory_linux.cc
-@@ -259,6 +259,7 @@ bool VideoCaptureDeviceFactoryLinux::HasUsableFormats(
-   if (!(capabilities & V4L2_CAP_VIDEO_CAPTURE))
-     return false;
- 
-+#if !defined(OS_FREEBSD)
-   const std::vector<uint32_t>& usable_fourccs =
-       VideoCaptureDeviceLinux::GetListOfUsableFourCCs(false);
-   v4l2_fmtdesc fmtdesc = {};
-@@ -267,6 +268,7 @@ bool VideoCaptureDeviceFactoryLinux::HasUsableFormats(
-     if (base::ContainsValue(usable_fourccs, fmtdesc.pixelformat))
-       return true;
-   }
-+#endif
- 
-   DVLOG(1) << "No usable formats found";
-   return false;
-@@ -312,9 +314,13 @@ void VideoCaptureDeviceFactoryLinux::GetSupportedForma
-   v4l2_format.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
-   for (; DoIoctl(fd, VIDIOC_ENUM_FMT, &v4l2_format) == 0; ++v4l2_format.index) {
-     VideoCaptureFormat supported_format;
-+#if !defined(OS_FREEBSD)
+@@ -315,6 +315,7 @@ void VideoCaptureDeviceFactoryLinux::GetSupportedForma
      supported_format.pixel_format =
          VideoCaptureDeviceLinux::V4l2FourCcToChromiumPixelFormat(
              v4l2_format.pixelformat);
-+#else
 +    supported_format.pixel_format = PIXEL_FORMAT_UNKNOWN;
-+#endif
  
      if (supported_format.pixel_format == PIXEL_FORMAT_UNKNOWN)
        continue;

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_linux_video__capture__device__linux.cc
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_media_capture_video_linux_video__capture__device__linux.cc
@@ -1,15 +1,17 @@
 --- src/3rdparty/chromium/media/capture/video/linux/video_capture_device_linux.cc.orig	2019-11-27 21:12:25 UTC
 +++ src/3rdparty/chromium/media/capture/video/linux/video_capture_device_linux.cc
-@@ -15,7 +15,7 @@
- 
- #if defined(OS_OPENBSD)
+@@ -17,8 +17,10 @@
  #include <sys/videoio.h>
--#else
-+#elif !defined(OS_FREEBSD)
+ #else
  #include <linux/videodev2.h>
++#if !defined(OS_FREEBSD)
  #include <linux/version.h>
  #endif
-@@ -31,17 +31,18 @@ int TranslatePowerLineFrequencyToV4L2(PowerLineFrequen
++#endif
+ 
+ namespace media {
+ 
+@@ -31,12 +33,12 @@ int TranslatePowerLineFrequencyToV4L2(PowerLineFrequen
      case PowerLineFrequency::FREQUENCY_60HZ:
        return V4L2_CID_POWER_LINE_FREQUENCY_60HZ;
      default:
@@ -26,60 +28,3 @@
    }
  }
  
- }  // namespace
- 
-+#if !defined(OS_FREEBSD)
- // Translates Video4Linux pixel formats to Chromium pixel formats.
- // static
- VideoPixelFormat VideoCaptureDeviceLinux::V4l2FourCcToChromiumPixelFormat(
-@@ -55,6 +56,7 @@ std::vector<uint32_t> VideoCaptureDeviceLinux::GetList
-     bool favour_mjpeg) {
-   return V4L2CaptureDelegate::GetListOfUsableFourCcs(favour_mjpeg);
- }
-+#endif // !defined(OS_FREEBSD)
- 
- VideoCaptureDeviceLinux::VideoCaptureDeviceLinux(
-     scoped_refptr<V4L2CaptureDevice> v4l2,
-@@ -76,6 +78,7 @@ void VideoCaptureDeviceLinux::AllocateAndStart(
-     const VideoCaptureParams& params,
-     std::unique_ptr<VideoCaptureDevice::Client> client) {
-   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-+#if !defined(OS_FREEBSD)
-   DCHECK(!capture_impl_);
-   if (v4l2_thread_.IsRunning())
-     return;  // Wrong state.
-@@ -103,10 +106,12 @@ void VideoCaptureDeviceLinux::AllocateAndStart(
-   for (auto& request : photo_requests_queue_)
-     v4l2_thread_.task_runner()->PostTask(FROM_HERE, std::move(request));
-   photo_requests_queue_.clear();
-+#endif // !defined(OS_FREEBSD)
- }
- 
- void VideoCaptureDeviceLinux::StopAndDeAllocate() {
-   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-+#if !defined(OS_FREEBSD)
-   if (!v4l2_thread_.IsRunning())
-     return;  // Wrong state.
-   v4l2_thread_.task_runner()->PostTask(
-@@ -116,6 +121,7 @@ void VideoCaptureDeviceLinux::StopAndDeAllocate() {
-   v4l2_thread_.Stop();
- 
-   capture_impl_ = nullptr;
-+#endif // !defined(OS_FREEBSD)
- }
- 
- void VideoCaptureDeviceLinux::TakePhoto(TakePhotoCallback callback) {
-@@ -163,11 +169,13 @@ void VideoCaptureDeviceLinux::SetPhotoOptions(
- void VideoCaptureDeviceLinux::SetRotation(int rotation) {
-   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-   rotation_ = rotation;
-+#if !defined(OS_FREEBSD)
-   if (v4l2_thread_.IsRunning()) {
-     v4l2_thread_.task_runner()->PostTask(
-         FROM_HERE, base::BindOnce(&V4L2CaptureDelegate::SetRotation,
-                                   capture_impl_->GetWeakPtr(), rotation));
-   }
-+#endif // !defined(OS_FREEBSD)
- }
- 
- }  // namespace media


### PR DESCRIPTION
The v4l video capture support was re-enabled for www/chromium in
r531050.  Do the same for www/qt5-webengine by removing the related
conditionals.

Deleting both of the patches for www/qt5-webengine doesn't quite work
because the compilation will fail then due non-present "linux/version.h"
header files.

Tested successfully on an Acer Aspire One netbook.

Builds fine on 11.3-, 12.1-RELEASE, 13.0-CURRENT@r359374 amd64 + i386 with ALSA/PULSEAUDIO/SNDIO (with/without DEBUG).