### PR TITLE
www/qt5-webengine: Update to 5.14.2

### DIFF
--- a/www/qt5-webengine/Makefile
+++ b/www/qt5-webengine/Makefile
@@ -48,7 +48,7 @@ LIB_DEPENDS=	libavcodec.so:multimedia/ffmpeg \
 		libwebp.so:graphics/webp
 
 DISTINFO_FILE=	${.CURDIR}/distinfo
-QT5_VERSION=	5.14.0
+QT5_VERSION=	5.14.2
 
 OPTIONS_SINGLE=		AUDIO
 OPTIONS_SINGLE_AUDIO=	ALSA PULSEAUDIO SNDIO

--- a/www/qt5-webengine/distinfo
+++ b/www/qt5-webengine/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1578321366
-SHA256 (KDE/Qt/5.14.0/qtwebengine-everywhere-src-5.14.0.tar.xz) = 74f8c11cc318612c8d9dc87cf791badb1efe7080c10d8b3ed5843b249a942d32
-SIZE (KDE/Qt/5.14.0/qtwebengine-everywhere-src-5.14.0.tar.xz) = 241565016
+TIMESTAMP = 1586559398
+SHA256 (KDE/Qt/5.14.2/qtwebengine-everywhere-src-5.14.2.tar.xz) = e169d6a75d8c397e04f843bc1b9585950fb9a001255cd18d6293f66fa8a6c947
+SIZE (KDE/Qt/5.14.2/qtwebengine-everywhere-src-5.14.2.tar.xz) = 242467568

--- a/www/qt5-webengine/files/patch-configure.pri
+++ b/www/qt5-webengine/files/patch-configure.pri
@@ -19,12 +19,3 @@
      }
  
      !isEmpty(platformError) {
-@@ -163,7 +166,7 @@ defineTest(qtConfTest_detectNinja) {
-     !isEmpty(ninja) {
-         qtLog("Found ninja from path: $$ninja")
-         qtRunLoggedCommand("$$ninja --version", version)|return(false)
--        contains(version, "1.[7-9].*"): return(true)
-+        contains(version, "1\.([7-9]|1[0-9])\..*"): return(true)
-         qtLog("Ninja version too old")
-     }
-     qtLog("Building own ninja")

--- a/www/qt5-webengine/files/patch-src_3rdparty_chromium_base_files_file__path__watcher__kqueue.h
+++ b/www/qt5-webengine/files/patch-src_3rdparty_chromium_base_files_file__path__watcher__kqueue.h
@@ -1,0 +1,13 @@
+--- src/3rdparty/chromium/base/files/file_path_watcher_kqueue.h.orig	2020-03-24 09:16:30 UTC
++++ src/3rdparty/chromium/base/files/file_path_watcher_kqueue.h
+@@ -5,6 +5,10 @@
+ #ifndef BASE_FILES_FILE_PATH_WATCHER_KQUEUE_H_
+ #define BASE_FILES_FILE_PATH_WATCHER_KQUEUE_H_
+ 
++#ifdef __FreeBSD__
++#include <sys/stdint.h>
++#include <sys/types.h>
++#endif
+ #include <sys/event.h>
+ 
+ #include <memory>

--- a/www/qt5-webengine/files/patch-src_3rdparty_gn_build_gen.py
+++ b/www/qt5-webengine/files/patch-src_3rdparty_gn_build_gen.py
@@ -1,14 +1,5 @@
 --- src/3rdparty/gn/build/gen.py.orig	2019-11-27 21:12:25 UTC
 +++ src/3rdparty/gn/build/gen.py
-@@ -46,7 +46,7 @@ class Platform(object):
- 
-   @staticmethod
-   def known_platforms():
--    return ['linux', 'darwin', 'msvc', 'aix', 'fuchsia', 'openbsd']
-+    return ['linux', 'darwin', 'msvc', 'aix', 'fuchsia', 'openbsd', 'freebsd']
- 
-   def platform(self):
-     return self._platform
 @@ -69,6 +69,9 @@ class Platform(object):
    def is_aix(self):
      return self._platform == 'aix'


### PR DESCRIPTION
Under the hood runs Chromium version to 77.0.3865.129 with security
patches up to 80.0.3987.132 .

Changelog:

* [QTBUG-78284] Fixed conversion of tabpanel aria role
* [QTBUG-81206] Fixed overriding shortcuts in password input fields
                on Windows
* [QTBUG-80234] Fixed media playback issue on custom urls by supporting HTTP
                ranges headers
* [QTBUG-81521] Update navigation actions when load finishes in a subframe
* [QTBUG-82109] Fixed name filters of GTK file picker
* [QTBUG-78284] Fixed widget accessibility on macOS
* [QTBUG-78284] Fixed quick accessibility on macOS
* [QTBUG-81783] Fixed event.key for Ctrl key combinations on Windows
* [QTBUG-81574] Clear previous page text selection on new navigation
                unconditionally
* [QTBUG-78284] Fixed VoiceOver navigation on web pages on macOS
* [QTBUG-81539] Update accessibility focus on FocusIn events for Quick
* [QTBUG-82715] Support build with system ninja >= 1.10.0
* Fixed deadlocks on WebEngineContext destruction
* Suppress error message on ACCESSIBILITY_EVENTS permission type
* Example 'quicknanobrowser' improvements

QA measures:
~~~~~~~~~~~~
* Builds fine on 11.3-, 12.1-RELEASE, 13.0-CURRENT@r359374 amd64 + i386
  with ALSA/PULSEAUDIO/SNDIO set and with/without DEBUG.

* Runtime looks ok (renders fine in multiple tabs, webcam works) and should
  be tested by 1-2 other people as more eyes sees usually more than only two
  eyes.

NOTE:
~~~~~
File patch-src_3rdparty_chromium_base_files_file__path__watcher__kqueue.h
that was added, should be re-added via "svn cp" because that patch existed
before and was deleted in r497425.