### PR TITLE
Skip calling xmllint on the svg files

### DIFF
--- a/x11-themes/kf5-breeze-icons/files/patch-validate__svg.sh
+++ b/x11-themes/kf5-breeze-icons/files/patch-validate__svg.sh
@@ -1,0 +1,12 @@
+--- validate_svg.sh.orig	2020-06-06 19:33:14 UTC
++++ validate_svg.sh
+@@ -1,6 +1,8 @@
+ #!/bin/sh
+ 
+-find "${1:-.}" -type f -name '*.svg' -exec xmllint --noout {} + 2> xmlerrors
++exit 0
++
++find "${1:-.}" -type f -name '*.svg' -exec xmllint --noout {} \; 2> xmlerrors
+ if [ -s xmlerrors ]; then
+     cat xmlerrors
+     rm xmlerrors


### PR DESCRIPTION
This decreases build time a great deal and makes build possible on lower
memory systems. Initially changed it to run serially instead of
parallel, left that for future reference.