### PR TITLE
[LibreSSL] Fix net/qt5-network build

### DIFF
--- a/net/qt5-network/files/patch-src_network_ssl_qsslcertificate__openssl.cpp
+++ b/net/qt5-network/files/patch-src_network_ssl_qsslcertificate__openssl.cpp
@@ -1,0 +1,12 @@
+Patch from Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtnetwork/files/qtnetwork-5.15.1-libressl.patch
+--- src/network/ssl/qsslcertificate_openssl.cpp.orig	2020-09-02 10:15:07 UTC
++++ src/network/ssl/qsslcertificate_openssl.cpp
+@@ -661,7 +661,7 @@ static QMultiMap<QByteArray, QString> _q_mapFromX509Na
+         unsigned char *data = nullptr;
+         int size = q_ASN1_STRING_to_UTF8(&data, q_X509_NAME_ENTRY_get_data(e));
+         info.insert(name, QString::fromUtf8((char*)data, size));
+-#if QT_CONFIG(opensslv11)
++#if QT_CONFIG(opensslv11) && !defined(LIBRESSL_VERSION_NUMBER)
+         q_CRYPTO_free(data, nullptr, 0);
+ #else
+         q_CRYPTO_free(data);

--- a/net/qt5-network/files/patch-src_network_ssl_qsslcontext__openssl.cpp
+++ b/net/qt5-network/files/patch-src_network_ssl_qsslcontext__openssl.cpp
@@ -1,18 +1,51 @@
---- src/network/ssl/qsslcontext_openssl.cpp.orig	2020-05-17 21:00:32 UTC
+Patch from Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtnetwork/files/qtnetwork-5.15.1-libressl.patch
+--- src/network/ssl/qsslcontext_openssl.cpp.orig	2020-09-02 10:15:07 UTC
 +++ src/network/ssl/qsslcontext_openssl.cpp
-@@ -696,6 +696,7 @@ void QSslContext::applyBackendConfig(QSslContext *sslC
+@@ -397,16 +397,28 @@ init_context:
+         maxVersion = DTLS1_VERSION;
+         break;
+     case QSsl::DtlsV1_0OrLater:
++#ifdef DTLS_MAX_VERSION
+         minVersion = DTLS1_VERSION;
+         maxVersion = DTLS_MAX_VERSION;
++#else
++        Q_UNREACHABLE();
++#endif // DTLS_MAX_VERSION
+         break;
+     case QSsl::DtlsV1_2:
++#ifdef DTLS1_2_VERSION
+         minVersion = DTLS1_2_VERSION;
+         maxVersion = DTLS1_2_VERSION;
++#else
++        Q_UNREACHABLE();
++#endif // DTLS1_2_VERSION
+         break;
+     case QSsl::DtlsV1_2OrLater:
++#if defined(DTLS1_2_VERSION) && defined(DTLS_MAX_VERSION)
+         minVersion = DTLS1_2_VERSION;
+         maxVersion = DTLS_MAX_VERSION;
++#else
++        Q_UNREACHABLE();
++#endif // DTLS1_2_VERSION && DTLS_MAX_VERSION
+         break;
+     case QSsl::TlsV1_3OrLater:
+ #ifdef TLS1_3_VERSION
+@@ -711,6 +723,7 @@ void QSslContext::applyBackendConfig(QSslContext *sslC
      }
  #endif // ocsp
  
-+#if !defined(LIBRESSL_VERSION_NUMBER)
++#ifndef LIBRESSL_VERSION_NUMBER
      QSharedPointer<SSL_CONF_CTX> cctx(q_SSL_CONF_CTX_new(), &q_SSL_CONF_CTX_free);
      if (cctx) {
          q_SSL_CONF_CTX_set_ssl_ctx(cctx.data(), sslContext->ctx);
-@@ -746,6 +747,7 @@ void QSslContext::applyBackendConfig(QSslContext *sslC
+@@ -757,7 +770,9 @@ void QSslContext::applyBackendConfig(QSslContext *sslC
+             sslContext->errorStr = msgErrorSettingBackendConfig(QSslSocket::tr("SSL_CONF_finish() failed"));
+             sslContext->errorCode = QSslError::UnspecifiedError;
+         }
+-    } else {
++    } else
++#endif // LIBRESSL_VERSION_NUMBER
++    {
          sslContext->errorStr = msgErrorSettingBackendConfig(QSslSocket::tr("SSL_CONF_CTX_new() failed"));
          sslContext->errorCode = QSslError::UnspecifiedError;
      }
-+#endif
- }
- 
- QT_END_NAMESPACE

--- a/net/qt5-network/files/patch-src_network_ssl_qsslcontext__openssl__p.h
+++ b/net/qt5-network/files/patch-src_network_ssl_qsslcontext__openssl__p.h
@@ -1,0 +1,17 @@
+Patch from Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtnetwork/files/qtnetwork-5.15.1-libressl.patch
+--- src/network/ssl/qsslcontext_openssl_p.h.orig	2020-09-02 10:15:07 UTC
++++ src/network/ssl/qsslcontext_openssl_p.h
+@@ -61,6 +61,13 @@
+ 
+ QT_BEGIN_NAMESPACE
+ 
++#ifndef DTLS_ANY_VERSION
++#define DTLS_ANY_VERSION 0x1FFFF
++#endif
++#ifndef TLS_ANY_VERSION
++#define TLS_ANY_VERSION 0x10000
++#endif
++
+ #ifndef QT_NO_SSL
+ 
+ class QSslContextPrivate;

--- a/net/qt5-network/files/patch-src_network_ssl_qsslsocket__openssl.cpp
+++ b/net/qt5-network/files/patch-src_network_ssl_qsslsocket__openssl.cpp
@@ -1,0 +1,12 @@
+Patch from Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtnetwork/files/qtnetwork-5.15.1-libressl.patch
+--- src/network/ssl/qsslsocket_openssl.cpp.orig	2020-09-02 10:15:07 UTC
++++ src/network/ssl/qsslsocket_openssl.cpp
+@@ -653,7 +653,7 @@ bool QSslSocketBackendPrivate::initSslContext()
+     else if (mode == QSslSocket::SslServerMode)
+         q_SSL_set_psk_server_callback(ssl, &q_ssl_psk_server_callback);
+ 
+-#if OPENSSL_VERSION_NUMBER >= 0x10101006L
++#if OPENSSL_VERSION_NUMBER >= 0x10101006L && !defined(LIBRESSL_VERSION_NUMBER)
+     // Set the client callback for TLSv1.3 PSK
+     if (mode == QSslSocket::SslClientMode
+         && QSslSocket::sslLibraryBuildVersionNumber() >= 0x10101006L) {

--- a/net/qt5-network/files/patch-src_network_ssl_qsslsocket__openssl__symbols.cpp
+++ b/net/qt5-network/files/patch-src_network_ssl_qsslsocket__openssl__symbols.cpp
@@ -1,33 +1,63 @@
---- src/network/ssl/qsslsocket_openssl_symbols.cpp.orig	2020-05-05 11:59:27 UTC
+Patch from Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtnetwork/files/qtnetwork-5.15.1-libressl.patch
+--- src/network/ssl/qsslsocket_openssl_symbols.cpp.orig	2020-09-02 10:15:07 UTC
 +++ src/network/ssl/qsslsocket_openssl_symbols.cpp
-@@ -147,6 +147,14 @@ DEFINEFUNC(int, EVP_CIPHER_CTX_reset, EVP_CIPHER_CTX *
+@@ -145,11 +145,14 @@ DEFINEFUNC(const BIO_METHOD *, BIO_s_mem, void, DUMMYA
+ DEFINEFUNC2(int, BN_is_word, BIGNUM *a, a, BN_ULONG w, w, return 0, return)
+ DEFINEFUNC(int, EVP_CIPHER_CTX_reset, EVP_CIPHER_CTX *c, c, return 0, return)
  DEFINEFUNC(int, EVP_PKEY_up_ref, EVP_PKEY *a, a, return 0, return)
++#ifdef OPENSSL_NO_DEPRECATED_3_0
+ DEFINEFUNC2(EVP_PKEY_CTX *, EVP_PKEY_CTX_new, EVP_PKEY *pkey, pkey, ENGINE *e, e, return nullptr, return)
+ DEFINEFUNC(int, EVP_PKEY_param_check, EVP_PKEY_CTX *ctx, ctx, return 0, return)
+ DEFINEFUNC(void, EVP_PKEY_CTX_free, EVP_PKEY_CTX *ctx, ctx, return, return)
++#endif // OPENSSL_NO_DEPRECATED_3_0
  DEFINEFUNC(int, EVP_PKEY_base_id, EVP_PKEY *a, a, return NID_undef, return)
  DEFINEFUNC(int, RSA_bits, RSA *a, a, return 0, return)
-+#ifdef LIBRESSL_VERSION_NUMBER
-+DEFINEFUNC(int, sk_num, OPENSSL_STACK *a, a, return -1, return)
-+DEFINEFUNC2(void, sk_pop_free, OPENSSL_STACK *a, a, void (*b)(void*), b, return, DUMMYARG)
-+DEFINEFUNC(OPENSSL_STACK *, sk_new_null, DUMMYARG, DUMMYARG, return nullptr, return)
-+DEFINEFUNC2(void, sk_push, OPENSSL_STACK *a, a, void *b, b, return, DUMMYARG)
-+DEFINEFUNC(void, sk_free, OPENSSL_STACK *a, a, return, DUMMYARG)
-+DEFINEFUNC2(void *, sk_value, OPENSSL_STACK *a, a, int b, b, return nullptr, return)
-+#else
++#ifndef LIBRESSL_VERSION_NUMBER
  DEFINEFUNC(int, DSA_bits, DSA *a, a, return 0, return)
  DEFINEFUNC(int, OPENSSL_sk_num, OPENSSL_STACK *a, a, return -1, return)
  DEFINEFUNC2(void, OPENSSL_sk_pop_free, OPENSSL_STACK *a, a, void (*b)(void*), b, return, DUMMYARG)
-@@ -154,6 +162,7 @@ DEFINEFUNC(OPENSSL_STACK *, OPENSSL_sk_new_null, DUMMY
+@@ -157,6 +160,14 @@ DEFINEFUNC(OPENSSL_STACK *, OPENSSL_sk_new_null, DUMMY
  DEFINEFUNC2(void, OPENSSL_sk_push, OPENSSL_STACK *a, a, void *b, b, return, DUMMYARG)
  DEFINEFUNC(void, OPENSSL_sk_free, OPENSSL_STACK *a, a, return, DUMMYARG)
  DEFINEFUNC2(void *, OPENSSL_sk_value, OPENSSL_STACK *a, a, int b, b, return nullptr, return)
-+#endif
++#else
++DEFINEFUNC(int, sk_num, STACK *a, a, return -1, return)
++DEFINEFUNC2(void, sk_pop_free, STACK *a, a, void (*b)(void*), b, return, DUMMYARG)
++DEFINEFUNC(_STACK *, sk_new_null, DUMMYARG, DUMMYARG, return nullptr, return)
++DEFINEFUNC2(void, sk_push, _STACK *a, a, void *b, b, return, DUMMYARG)
++DEFINEFUNC(void, sk_free, _STACK *a, a, return, DUMMYARG)
++DEFINEFUNC2(void *, sk_value, STACK *a, a, int b, b, return nullptr, return)
++#endif // LIBRESSL_VERSION_NUMBER
  DEFINEFUNC(int, SSL_session_reused, SSL *a, a, return 0, return)
  DEFINEFUNC2(unsigned long, SSL_CTX_set_options, SSL_CTX *ctx, ctx, unsigned long op, op, return 0, return)
  #ifdef TLS1_3_VERSION
-@@ -351,12 +360,14 @@ DEFINEFUNC2(int, SSL_CTX_use_PrivateKey, SSL_CTX *a, a
+@@ -182,7 +193,11 @@ DEFINEFUNC2(void, X509_STORE_set_verify_cb, X509_STORE
+ DEFINEFUNC3(int, X509_STORE_set_ex_data, X509_STORE *a, a, int idx, idx, void *data, data, return 0, return)
+ DEFINEFUNC2(void *, X509_STORE_get_ex_data, X509_STORE *r, r, int idx, idx, return nullptr, return)
+ DEFINEFUNC(STACK_OF(X509) *, X509_STORE_CTX_get0_chain, X509_STORE_CTX *a, a, return nullptr, return)
++#ifndef LIBRESSL_VERSION_NUMBER
+ DEFINEFUNC3(void, CRYPTO_free, void *str, str, const char *file, file, int line, line, return, DUMMYARG)
++#else
++DEFINEFUNC(void, CRYPTO_free, void *a, a, return, DUMMYARG)
++#endif
+ DEFINEFUNC(long, OpenSSL_version_num, void, DUMMYARG, return 0, return)
+ DEFINEFUNC(const char *, OpenSSL_version, int a, a, return nullptr, return)
+ DEFINEFUNC(unsigned long, SSL_SESSION_get_ticket_lifetime_hint, const SSL_SESSION *session, session, return 0, return)
+@@ -222,7 +237,9 @@ DEFINEFUNC5(int, OCSP_id_get0_info, ASN1_OCTET_STRING 
+             ASN1_OCTET_STRING **piKeyHash, piKeyHash, ASN1_INTEGER **pserial, pserial, OCSP_CERTID *cid, cid,
+             return 0, return)
+ DEFINEFUNC2(OCSP_RESPONSE *, OCSP_response_create, int status, status, OCSP_BASICRESP *bs, bs, return nullptr, return)
++#ifndef LIBRESSL_VERSION_NUMBER
+ DEFINEFUNC(const STACK_OF(X509) *, OCSP_resp_get0_certs, const OCSP_BASICRESP *bs, bs, return nullptr, return)
++#endif
+ DEFINEFUNC2(int, OCSP_id_cmp, OCSP_CERTID *a, a, OCSP_CERTID *b, b, return -1, return)
+ DEFINEFUNC7(OCSP_SINGLERESP *, OCSP_basic_add1_status, OCSP_BASICRESP *r, r, OCSP_CERTID *c, c, int s, s,
+             int re, re, ASN1_TIME *rt, rt, ASN1_TIME *t, t, ASN1_TIME *n, n, return nullptr, return)
+@@ -354,12 +371,14 @@ DEFINEFUNC2(int, SSL_CTX_use_PrivateKey, SSL_CTX *a, a
  DEFINEFUNC2(int, SSL_CTX_use_RSAPrivateKey, SSL_CTX *a, a, RSA *b, b, return -1, return)
  DEFINEFUNC3(int, SSL_CTX_use_PrivateKey_file, SSL_CTX *a, a, const char *b, b, int c, c, return -1, return)
  DEFINEFUNC(X509_STORE *, SSL_CTX_get_cert_store, const SSL_CTX *a, a, return nullptr, return)
-+#if !defined(LIBRESSL_VERSION_NUMBER)
++#ifndef LIBRESSL_VERSION_NUMBER
  DEFINEFUNC(SSL_CONF_CTX *, SSL_CONF_CTX_new, DUMMYARG, DUMMYARG, return nullptr, return);
  DEFINEFUNC(void, SSL_CONF_CTX_free, SSL_CONF_CTX *a, a, return ,return);
  DEFINEFUNC2(void, SSL_CONF_CTX_set_ssl_ctx, SSL_CONF_CTX *a, a, SSL_CTX *b, b, return, return);
@@ -38,18 +68,18 @@
  DEFINEFUNC(void, SSL_free, SSL *a, a, return, DUMMYARG)
  DEFINEFUNC(STACK_OF(SSL_CIPHER) *, SSL_get_ciphers, const SSL *a, a, return nullptr, return)
  DEFINEFUNC(const SSL_CIPHER *, SSL_get_current_cipher, SSL *a, a, return nullptr, return)
-@@ -834,12 +845,21 @@ bool q_resolveOpenSslSymbols()
+@@ -843,17 +862,21 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(ASN1_STRING_get0_data)
+     RESOLVEFUNC(EVP_CIPHER_CTX_reset)
      RESOLVEFUNC(EVP_PKEY_up_ref)
++#ifdef OPENSSL_NO_DEPRECATED_3_0
+     RESOLVEFUNC(EVP_PKEY_CTX_new)
+     RESOLVEFUNC(EVP_PKEY_param_check)
+     RESOLVEFUNC(EVP_PKEY_CTX_free)
++#endif // OPENSSL_NO_DEPRECATED_3_0
      RESOLVEFUNC(EVP_PKEY_base_id)
      RESOLVEFUNC(RSA_bits)
-+#ifdef LIBRESSL_VERSION_NUMBER
-+    RESOLVEFUNC(sk_new_null)
-+    RESOLVEFUNC(sk_push)
-+    RESOLVEFUNC(sk_free)
-+    RESOLVEFUNC(sk_num)
-+    RESOLVEFUNC(sk_pop_free)
-+    RESOLVEFUNC(sk_value)
-+#else
++#ifndef LIBRESSL_VERSION_NUMBER
      RESOLVEFUNC(OPENSSL_sk_new_null)
      RESOLVEFUNC(OPENSSL_sk_push)
      RESOLVEFUNC(OPENSSL_sk_free)
@@ -60,7 +90,7 @@
      RESOLVEFUNC(DH_get0_pqg)
      RESOLVEFUNC(SSL_CTX_set_options)
  
-@@ -881,7 +901,9 @@ bool q_resolveOpenSslSymbols()
+@@ -895,7 +918,9 @@ bool q_resolveOpenSslSymbols()
  
      RESOLVEFUNC(SSL_SESSION_get_ticket_lifetime_hint)
      RESOLVEFUNC(DH_bits)
@@ -70,11 +100,21 @@
  
  #if QT_CONFIG(dtls)
      RESOLVEFUNC(DTLSv1_listen)
-@@ -1041,12 +1063,14 @@ bool q_resolveOpenSslSymbols()
+@@ -925,7 +950,9 @@ bool q_resolveOpenSslSymbols()
+     RESOLVEFUNC(OCSP_check_validity)
+     RESOLVEFUNC(OCSP_cert_to_id)
+     RESOLVEFUNC(OCSP_id_get0_info)
++#ifndef LIBRESSL_VERSION_NUMBER
+     RESOLVEFUNC(OCSP_resp_get0_certs)
++#endif
+     RESOLVEFUNC(OCSP_basic_sign)
+     RESOLVEFUNC(OCSP_response_create)
+     RESOLVEFUNC(i2d_OCSP_RESPONSE)
+@@ -1055,12 +1082,14 @@ bool q_resolveOpenSslSymbols()
      RESOLVEFUNC(SSL_CTX_use_RSAPrivateKey)
      RESOLVEFUNC(SSL_CTX_use_PrivateKey_file)
      RESOLVEFUNC(SSL_CTX_get_cert_store);
-+#if !defined(LIBRESSL_VERSION_NUMBER)
++#ifndef LIBRESSL_VERSION_NUMBER
      RESOLVEFUNC(SSL_CONF_CTX_new);
      RESOLVEFUNC(SSL_CONF_CTX_free);
      RESOLVEFUNC(SSL_CONF_CTX_set_ssl_ctx);

--- a/net/qt5-network/files/patch-src_network_ssl_qsslsocket__openssl__symbols__p.h
+++ b/net/qt5-network/files/patch-src_network_ssl_qsslsocket__openssl__symbols__p.h
@@ -1,90 +1,95 @@
---- src/network/ssl/qsslsocket_openssl_symbols_p.h.orig	2020-05-05 11:59:27 UTC
+Patch from Gentoo: https://gitweb.gentoo.org/repo/gentoo.git/plain/dev-qt/qtnetwork/files/qtnetwork-5.15.1-libressl.patch
+--- src/network/ssl/qsslsocket_openssl_symbols_p.h.orig	2020-09-02 10:15:07 UTC
 +++ src/network/ssl/qsslsocket_openssl_symbols_p.h
-@@ -72,6 +72,14 @@
- #include "qsslsocket_openssl_p.h"
- #include <QtCore/qglobal.h>
+@@ -80,6 +80,13 @@ QT_BEGIN_NAMESPACE
  
-+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x20700000L
-+# define TLS1_2_VERSION 0x0303
-+# define TLS_MAX_VERSION TLS1_2_VERSION
-+# define TLS_ANY_VERSION 0x10000
-+# define DTLS1_2_VERSION                 0xFEFD
-+# define DTLS_MAX_VERSION                DTLS1_2_VERSION
+ #define DUMMYARG
+ 
++#ifdef LIBRESSL_VERSION_NUMBER
++typedef _STACK STACK;
++typedef STACK OPENSSL_STACK;
++typedef void OPENSSL_INIT_SETTINGS;
++typedef int (*X509_STORE_CTX_verify_cb)(int ok,X509_STORE_CTX *ctx);
 +#endif
 +
- #if QT_CONFIG(ocsp)
- #include "qocsp_p.h"
- #endif
-@@ -225,22 +233,50 @@ QT_BEGIN_NAMESPACE
- // content of the header here. Later, can be better sorted/split into groups,
- // depending on the functionality.
- 
-+#if defined(LIBRESSL_VERSION_NUMBER) && LIBRESSL_VERSION_NUMBER >= 0x20700000L
-+// LibreSSL 2.7 has stack_st but not OPENSSL_STACK
-+typedef struct stack_st OPENSSL_STACK; /* Use STACK_OF(...) instead */
-+// From the signature in LibreSSL
-+#define OPENSSL_INIT_SETTINGS void
-+// https://github.com/openssl/openssl/blob/master/include/openssl/x509_vfy.h#L63
-+typedef int (*X509_STORE_CTX_verify_cb)(int, X509_STORE_CTX *);
-+#endif
-+
- const unsigned char * q_ASN1_STRING_get0_data(const ASN1_STRING *x);
- 
+ #if !defined QT_LINKED_OPENSSL
+ // **************** Shared declarations ******************
+ // ret func(arg)
+@@ -230,20 +237,43 @@ const unsigned char * q_ASN1_STRING_get0_data(const AS
  Q_AUTOTEST_EXPORT BIO *q_BIO_new(const BIO_METHOD *a);
  Q_AUTOTEST_EXPORT const BIO_METHOD *q_BIO_s_mem();
  
-+#ifdef LIBRESSL_VERSION_NUMBER
-+#define q_DSA_bits(dsa) q_BN_num_bits((dsa)->p)
-+#else
++#ifndef LIBRESSL_VERSION_NUMBER
  int q_DSA_bits(DSA *a);
++#else
++#define q_DSA_bits(dsa) q_BN_num_bits((dsa)->p)
 +#endif
  int q_EVP_CIPHER_CTX_reset(EVP_CIPHER_CTX *c);
  Q_AUTOTEST_EXPORT int q_EVP_PKEY_up_ref(EVP_PKEY *a);
++#ifdef OPENSSL_NO_DEPRECATED_3_0
+ EVP_PKEY_CTX *q_EVP_PKEY_CTX_new(EVP_PKEY *pkey, ENGINE *e);
+ void q_EVP_PKEY_CTX_free(EVP_PKEY_CTX *ctx);
+ int q_EVP_PKEY_param_check(EVP_PKEY_CTX *ctx);
++#endif // OPENSSL_NO_DEPRECATED_3_0
  int q_EVP_PKEY_base_id(EVP_PKEY *a);
  int q_RSA_bits(RSA *a);
-+#ifdef LIBRESSL_VERSION_NUMBER
-+int q_sk_num(OPENSSL_STACK *a);
-+void q_sk_pop_free(OPENSSL_STACK *a, void (*b)(void *));
-+OPENSSL_STACK *q_sk_new_null();
-+void q_sk_push(OPENSSL_STACK *st, void *data);
-+void q_sk_free(OPENSSL_STACK *a);
-+void * q_sk_value(OPENSSL_STACK *a, int b);
-+#define q_OPENSSL_sk_num(a) q_sk_num(a)
-+#define q_OPENSSL_sk_pop_free(a, b) q_sk_pop_free(a, b)
-+#define q_OPENSSL_sk_new_null() q_sk_new_null()
-+#define q_OPENSSL_sk_push(a, b) q_sk_push(a, b)
-+#define q_OPENSSL_sk_free q_sk_free
-+#define q_OPENSSL_sk_value(a, b) q_sk_value(a, b)
-+#else
++
++#ifndef LIBRESSL_VERSION_NUMBER
  Q_AUTOTEST_EXPORT int q_OPENSSL_sk_num(OPENSSL_STACK *a);
  Q_AUTOTEST_EXPORT void q_OPENSSL_sk_pop_free(OPENSSL_STACK *a, void (*b)(void *));
  Q_AUTOTEST_EXPORT OPENSSL_STACK *q_OPENSSL_sk_new_null();
  Q_AUTOTEST_EXPORT void q_OPENSSL_sk_push(OPENSSL_STACK *st, void *data);
  Q_AUTOTEST_EXPORT void q_OPENSSL_sk_free(OPENSSL_STACK *a);
  Q_AUTOTEST_EXPORT void * q_OPENSSL_sk_value(OPENSSL_STACK *a, int b);
-+#endif
++#else // LIBRESSL_VERSION_NUMBER
++int q_sk_num(STACK *a);
++#define q_OPENSSL_sk_num(a) q_sk_num(a)
++void q_sk_pop_free(STACK *a, void (*b)(void *));
++#define q_OPENSSL_sk_pop_free(a, b) q_sk_pop_free(a, b)
++STACK *q_sk_new_null();
++#define q_OPENSSL_sk_new_null() q_sk_new_null()
++void q_sk_push(STACK *st, void *data);
++#define q_OPENSSL_sk_push(st, data) q_sk_push(st, data)
++void q_sk_free(STACK *a);
++#define q_OPENSSL_sk_free q_sk_free
++void *q_sk_value(STACK *a, int b);
++#define q_OPENSSL_sk_value(a, b) q_sk_value(a, b)
++#endif // LIBRESSL_VERSION_NUMBER
++
  int q_SSL_session_reused(SSL *a);
  unsigned long q_SSL_CTX_set_options(SSL_CTX *ctx, unsigned long op);
  int q_OPENSSL_init_ssl(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
-@@ -266,8 +302,13 @@ int q_DH_bits(DH *dh);
+@@ -269,8 +299,13 @@ int q_DH_bits(DH *dh);
  # define q_SSL_load_error_strings() q_OPENSSL_init_ssl(OPENSSL_INIT_LOAD_SSL_STRINGS \
                                                         | OPENSSL_INIT_LOAD_CRYPTO_STRINGS, NULL)
  
-+#ifdef LIBRESSL_VERSION_NUMBER
-+#define q_SKM_sk_num(type, st) ((int (*)(const STACK_OF(type) *))q_sk_num)(st)
-+#define q_SKM_sk_value(type, st,i) ((type * (*)(const STACK_OF(type) *, int))q_sk_value)(st, i)
-+#else
++#ifndef LIBRESSL_VERSION_NUMBER
  #define q_SKM_sk_num(type, st) ((int (*)(const STACK_OF(type) *))q_OPENSSL_sk_num)(st)
  #define q_SKM_sk_value(type, st,i) ((type * (*)(const STACK_OF(type) *, int))q_OPENSSL_sk_value)(st, i)
-+#endif
++#else
++#define q_SKM_sk_num(type, st) ((int (*)(const STACK_OF(type) *))q_sk_num)(st)
++#define q_SKM_sk_value(type, st,i) ((type * (*)(const STACK_OF(type) *, int))q_sk_value)(st, i)
++#endif // LIBRESSL_VERSION_NUMBER
  
  #define q_OPENSSL_add_all_algorithms_conf()  q_OPENSSL_init_crypto(OPENSSL_INIT_ADD_ALL_CIPHERS \
                                                                     | OPENSSL_INIT_ADD_ALL_DIGESTS \
-@@ -494,12 +535,14 @@ int q_SSL_CTX_use_PrivateKey(SSL_CTX *a, EVP_PKEY *b);
+@@ -279,7 +314,11 @@ int q_DH_bits(DH *dh);
+                                                                     | OPENSSL_INIT_ADD_ALL_DIGESTS, NULL)
+ 
+ int q_OPENSSL_init_crypto(uint64_t opts, const OPENSSL_INIT_SETTINGS *settings);
++#ifndef LIBRESSL_VERSION_NUMBER
+ void q_CRYPTO_free(void *str, const char *file, int line);
++#else
++void q_CRYPTO_free(void *a);
++#endif
+ 
+ long q_OpenSSL_version_num();
+ const char *q_OpenSSL_version(int type);
+@@ -497,12 +536,14 @@ int q_SSL_CTX_use_PrivateKey(SSL_CTX *a, EVP_PKEY *b);
  int q_SSL_CTX_use_RSAPrivateKey(SSL_CTX *a, RSA *b);
  int q_SSL_CTX_use_PrivateKey_file(SSL_CTX *a, const char *b, int c);
  X509_STORE *q_SSL_CTX_get_cert_store(const SSL_CTX *a);
-+#if !defined(LIBRESSL_VERSION_NUMBER)
++#ifndef LIBRESSL_VERSION_NUMBER
  SSL_CONF_CTX *q_SSL_CONF_CTX_new();
  void q_SSL_CONF_CTX_free(SSL_CONF_CTX *a);
  void q_SSL_CONF_CTX_set_ssl_ctx(SSL_CONF_CTX *a, SSL_CTX *b);
@@ -95,3 +100,15 @@
  void q_SSL_free(SSL *a);
  STACK_OF(SSL_CIPHER) *q_SSL_get_ciphers(const SSL *a);
  const SSL_CIPHER *q_SSL_get_current_cipher(SSL *a);
+@@ -728,7 +769,11 @@ int q_OCSP_check_validity(ASN1_GENERALIZEDTIME *thisup
+ int q_OCSP_id_get0_info(ASN1_OCTET_STRING **piNameHash, ASN1_OBJECT **pmd, ASN1_OCTET_STRING **pikeyHash,
+                         ASN1_INTEGER **pserial, OCSP_CERTID *cid);
+ 
++#ifndef LIBRESSL_VERSION_NUMBER
+ const STACK_OF(X509) *q_OCSP_resp_get0_certs(const OCSP_BASICRESP *bs);
++#else
++#define q_OCSP_resp_get0_certs(bs) ((bs)->certs)
++#endif
+ Q_AUTOTEST_EXPORT OCSP_CERTID *q_OCSP_cert_to_id(const EVP_MD *dgst, X509 *subject, X509 *issuer);
+ Q_AUTOTEST_EXPORT void q_OCSP_CERTID_free(OCSP_CERTID *cid);
+ int q_OCSP_id_cmp(OCSP_CERTID *a, OCSP_CERTID *b);


### PR DESCRIPTION

Tested without LibreSSL and with LibreSSL:
```
% cat /usr/local/etc/poudriere.d/12amd64-svn-libressl-make.conf 
DEFAULT_VERSIONS+= ssl=libressl
% doas poudriere bulk -C -t -j 12amd64 -p qt5 -z libressl net/qt5-network
```

