### PR TITLE
Pyside2: update to 5.15.2

### DIFF
--- a/devel/pyside2-tools/Makefile
+++ b/devel/pyside2-tools/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pyside2-tools
-DISTVERSION=	5.15.1
+DISTVERSION=	5.15.2
 CATEGORIES=	devel
 MASTER_SITES=	QT/official_releases/QtForPython/shiboken2/PySide2-${DISTVERSION}-src
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}

--- a/devel/pyside2-tools/distinfo
+++ b/devel/pyside2-tools/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1601627385
-SHA256 (pyside-setup-opensource-src-5.15.1.tar.xz) = f175c1d8813257904cf0efeb58e44f68d53b9916f73adaf9ce19514c0271c3fa
-SIZE (pyside-setup-opensource-src-5.15.1.tar.xz) = 3454052
+TIMESTAMP = 1606840487
+SHA256 (pyside-setup-opensource-src-5.15.2.tar.xz) = b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418
+SIZE (pyside-setup-opensource-src-5.15.2.tar.xz) = 3472624

--- a/devel/pyside2/Makefile
+++ b/devel/pyside2/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	pyside2
-DISTVERSION=	5.15.1
+DISTVERSION=	5.15.2
 CATEGORIES=	devel
 MASTER_SITES=	QT/official_releases/QtForPython/shiboken2/PySide2-${DISTVERSION}-src
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -42,5 +42,15 @@ USE_QT+=	webengine
 .else
 PLIST_SUB+=	WEBENGINE="@comment "
 .endif
+
+# AVOID a build_fs_violation with poudriere
+post-build:
+	${RM} -r ${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__
+	${RM} -r ${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__
+	${RM} -r ${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__
+post-stage:
+	${RM} -r ${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__
+	${RM} -r ${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__
+	${RM} -r ${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__
 
 .include <bsd.port.post.mk>

--- a/devel/pyside2/distinfo
+++ b/devel/pyside2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1601626288
-SHA256 (pyside-setup-opensource-src-5.15.1.tar.xz) = f175c1d8813257904cf0efeb58e44f68d53b9916f73adaf9ce19514c0271c3fa
-SIZE (pyside-setup-opensource-src-5.15.1.tar.xz) = 3454052
+TIMESTAMP = 1606754632
+SHA256 (pyside-setup-opensource-src-5.15.2.tar.xz) = b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418
+SIZE (pyside-setup-opensource-src-5.15.2.tar.xz) = 3472624

--- a/devel/shiboken2/Makefile
+++ b/devel/shiboken2/Makefile
@@ -34,29 +34,10 @@ CMAKE_ARGS+=	"-DCMAKE_CXX_FLAGS=-lexecinfo" \
 		"-DUSE_PYTHON_VERSION=${PYTHON_VER}"
 
 .include <bsd.port.pre.mk>
-#CPYVER=		.cpython-${PYTHON_SUFFIX}
 
 PLIST_SUB+=	DISTVERSION=${DISTVERSION}
-#PLIST_SUB+=	CPYVER=${CPYVER}
 PLIST_SUB+=	PYVERSTR=.cpython-${PYTHON_SUFFIX}${PYTHON_ABIVER}
 
 WRKSRC=		${WRKDIR}/pyside-setup-opensource-src-${DISTVERSION:C/^([0-9].[0-9]+.[0-9])(.[0-9])?/\1/}/sources/shiboken2
-
-#post-build:
-#	${MKDIR} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__/__feature__${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__/__init__${CPYVER}.pyc
-#	${MKDIR} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/importhandler${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/layout${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/__init__${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/errorhandler${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/loader${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/mapping${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/parser${CPYVER}.pyc
-#	${MKDIR} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__/enum_sig${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__/__init__${CPYVER}.pyc
-#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__/tool${CPYVER}.pyc
 
 .include <bsd.port.post.mk>

--- a/devel/shiboken2/Makefile
+++ b/devel/shiboken2/Makefile
@@ -1,7 +1,7 @@
 # $FreeBSD$
 
 PORTNAME=	shiboken2
-DISTVERSION=	5.15.1
+DISTVERSION=	5.15.2
 CATEGORIES=	devel
 MASTER_SITES=	QT/official_releases/QtForPython/shiboken2/PySide2-${DISTVERSION}-src
 PKGNAMEPREFIX=	${PYTHON_PKGNAMEPREFIX}
@@ -34,10 +34,29 @@ CMAKE_ARGS+=	"-DCMAKE_CXX_FLAGS=-lexecinfo" \
 		"-DUSE_PYTHON_VERSION=${PYTHON_VER}"
 
 .include <bsd.port.pre.mk>
+#CPYVER=		.cpython-${PYTHON_SUFFIX}
 
 PLIST_SUB+=	DISTVERSION=${DISTVERSION}
+#PLIST_SUB+=	CPYVER=${CPYVER}
 PLIST_SUB+=	PYVERSTR=.cpython-${PYTHON_SUFFIX}${PYTHON_ABIVER}
 
 WRKSRC=		${WRKDIR}/pyside-setup-opensource-src-${DISTVERSION:C/^([0-9].[0-9]+.[0-9])(.[0-9])?/\1/}/sources/shiboken2
+
+#post-build:
+#	${MKDIR} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__/__feature__${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/__pycache__/__init__${CPYVER}.pyc
+#	${MKDIR} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/importhandler${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/layout${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/__init__${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/errorhandler${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/loader${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/mapping${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/__pycache__/parser${CPYVER}.pyc
+#	${MKDIR} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__/enum_sig${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__/__init__${CPYVER}.pyc
+#	${TOUCH} ${STAGEDIR}${PYTHON_SITELIBDIR}/shiboken2/files.dir/shibokensupport/signature/lib/__pycache__/tool${CPYVER}.pyc
 
 .include <bsd.port.post.mk>

--- a/devel/shiboken2/distinfo
+++ b/devel/shiboken2/distinfo
@@ -1,3 +1,3 @@
-TIMESTAMP = 1601626006
-SHA256 (pyside-setup-opensource-src-5.15.1.tar.xz) = f175c1d8813257904cf0efeb58e44f68d53b9916f73adaf9ce19514c0271c3fa
-SIZE (pyside-setup-opensource-src-5.15.1.tar.xz) = 3454052
+TIMESTAMP = 1606807809
+SHA256 (pyside-setup-opensource-src-5.15.2.tar.xz) = b306504b0b8037079a8eab772ee774b9e877a2d84bab2dbefbe4fa6f83941418
+SIZE (pyside-setup-opensource-src-5.15.2.tar.xz) = 3472624

--- a/devel/shiboken2/pkg-plist
+++ b/devel/shiboken2/pkg-plist
@@ -22,6 +22,7 @@ include/shiboken2/shiboken.h
 include/shiboken2/shibokenbuffer.h
 include/shiboken2/shibokenmacros.h
 include/shiboken2/signature.h
+include/shiboken2/signature_p.h
 include/shiboken2/threadstatesaver.h
 include/shiboken2/typespec.h
 include/shiboken2/voidptr.h


### PR DESCRIPTION
@adriaandegroot @tcberner I think devel/pyside2{-tools} and devel/shiboken2 must also be updated with Qt.

BTW, is these ports should be under kde@ team?